### PR TITLE
CSL-20 Ensure failure of cron security_scans pipeline for failing node/os scan steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -412,7 +412,7 @@ steps:
         IMAGE_NAME: sas/csl:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
-        FAIL_ON_DETECTION: false
+        FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
@@ -428,7 +428,7 @@ steps:
     environment:
         IMAGE_NAME: node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
-        FAIL_ON_DETECTION: false
+        FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:


### PR DESCRIPTION
## What? 

Makes scheduled `security_scans` pipeline job fail in the case of vulnerabilities found in node package or OS scans

## Why? 

As with HOF ways of working for vulnerabilities, these scheduled scans should fail to alert us of security issues in this project. They should also trigger a slack alert in the relevant HOF slack channel.

## How? 

Updated `FAIL_ON_DETECTION` bool for scan jobs `cron_trivy_scan_node_packages` and `cron_trivy_scan_image_os` in `.drone.yml`

## Testing?

This can be tested by temporarily increasing the cron schedule and checking if we receive all required notification.

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


