### PR TITLE
CSL-20: Make trigger conditions for slack pipeline steps a list

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -457,7 +457,8 @@ steps:
     when:
       cron: tear_down_pr_envs
       event: cron
-      status: failure
+      status:
+        - failure
 
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -478,7 +479,8 @@ steps:
     when:
       cron: security_scans
       event: cron
-      status: failure
+      status:
+        - failure
 
 services:
   - name: docker


### PR DESCRIPTION
## What? 

Made the trigger condition for slack hook steps based on failure status in cron pipelines a list instead of a plain key/value value.

## Why? 

The previous config did not trigger the slack hook step when the pipeline had failed on a previous step. this update alters it to match other working pipeline steps in other projects and [drone's documentation on triggers](https://docs.drone.io/pipeline/kubernetes/syntax/trigger/#by-status).
