### PR TITLE
CSL-44 Update cron step dependencies to ensure slack step runs in scan failure cases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -419,7 +419,6 @@ steps:
       cron: fail_security_scans
       event: cron
     depends_on:
-      - cron_clone_repos
       - cron_build_image
 
   - name: cron_trivy_scan_image_os

--- a/.drone.yml
+++ b/.drone.yml
@@ -370,7 +370,7 @@ steps:
     commands:
       - bin/clean_up.sh $${BRANCH_ENV}
     when:
-      cron: fail_tear_down_pr_envs
+      cron: tear_down_pr_envs
       event: cron
 
   # CRON job steps that runs security scans using Trivy
@@ -386,7 +386,7 @@ steps:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
       - find hof-services-config/* | grep -v $HOF_CONFIG | grep -v 'infrastructure' | xargs rm -rf
     when:
-      cron: fail_security_scans
+      cron: security_scans
       event: cron
 
   - name: cron_build_image
@@ -400,7 +400,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: fail_security_scans
+      cron: security_scans
       event: cron
     depends_on:
       - cron_clone_repos
@@ -416,7 +416,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: fail_security_scans
+      cron: security_scans
       event: cron
       status:
         - success
@@ -434,7 +434,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: fail_security_scans
+      cron: security_scans
       event: cron
     depends_on:
       - cron_clone_repos
@@ -457,7 +457,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: fail_tear_down_pr_envs
+      cron: tear_down_pr_envs
       event: cron
       status:
         - failure
@@ -481,7 +481,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: fail_security_scans
+      cron: security_scans
       event: cron
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -370,7 +370,7 @@ steps:
     commands:
       - bin/clean_up.sh $${BRANCH_ENV}
     when:
-      cron: tear_down_pr_envs
+      cron: fail_tear_down_pr_envs
       event: cron
 
   # CRON job steps that runs security scans using Trivy
@@ -418,6 +418,9 @@ steps:
     when:
       cron: fail_security_scans
       event: cron
+      status:
+        - success
+        - failure
     depends_on:
       - cron_build_image
 
@@ -454,7 +457,7 @@ steps:
       webhook:
         from_secret: slack_sas_hof_build_notify_webhook
     when:
-      cron: tear_down_pr_envs
+      cron: fail_tear_down_pr_envs
       event: cron
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -386,7 +386,7 @@ steps:
       - git clone https://$${DRONE_GIT_USERNAME}:$${DRONE_GIT_TOKEN}@github.com/UKHomeOfficeForms/hof-services-config.git
       - find hof-services-config/* | grep -v $HOF_CONFIG | grep -v 'infrastructure' | xargs rm -rf
     when:
-      cron: security_scans
+      cron: fail_security_scans
       event: cron
 
   - name: cron_build_image
@@ -400,7 +400,7 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      cron: security_scans
+      cron: fail_security_scans
       event: cron
     depends_on:
       - cron_clone_repos
@@ -416,7 +416,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: fail_security_scans
       event: cron
     depends_on:
       - cron_clone_repos
@@ -432,7 +432,7 @@ steps:
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      cron: security_scans
+      cron: fail_security_scans
       event: cron
     depends_on:
       - cron_clone_repos
@@ -459,6 +459,8 @@ steps:
       event: cron
       status:
         - failure
+    depends_on:
+      - cron_tear_down
 
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -477,10 +479,13 @@ steps:
       webhook:
         from_secret: slack_sas_hof_security_webhook
     when:
-      cron: security_scans
+      cron: fail_security_scans
       event: cron
       status:
         - failure
+    depends_on:
+      - cron_trivy_scan_image_os
+      - cron_trivy_scan_node_packages
 
 services:
   - name: docker

--- a/bin/clean_up.sh
+++ b/bin/clean_up.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 set -e
 
+exit 1
+
 export KUBE_NAMESPACE=$1
 export IGNORE_NETPOL=("acp-deny-all")
 export IGNORE_CONFIGMAP=("bundle")

--- a/bin/clean_up.sh
+++ b/bin/clean_up.sh
@@ -1,8 +1,6 @@
 #! /bin/bash
 set -e
 
-exit 1
-
 export KUBE_NAMESPACE=$1
 export IGNORE_NETPOL=("acp-deny-all")
 export IGNORE_CONFIGMAP=("bundle")


### PR DESCRIPTION
## What? 

Update dependencies of `security_scans` steps in the pipeline so that the slack notification step will successfully run if failure is detected in the vulnerability scan steps.

## Why? 

The slack hook step was not running before as it was not detecting failures or was skipping before.