### PR TITLE
CSL-26: PCA - Add list of chemicals

### DIFF
--- a/apps/precursor-chemicals/data/chemicals.json
+++ b/apps/precursor-chemicals/data/chemicals.json
@@ -1,0 +1,212 @@
+[
+  {
+    "label": "1-phenyl-2-propanone (BMK) (2914 3100)",
+    "value": "1-phenyl-2-propanone (BMK)",
+    "category": "1",
+    "cnCode": "2914 3100"
+  },
+  {
+    "label": "3-4 Methylenedioxy-Phenylpropan-2-one (PMK) (2932 9200)",
+    "value": "3-4 Methylenedioxy-Phenylpropan-2-one (PMK)",
+    "category": "1",
+    "cnCode": "2932 9200"
+  },
+  {
+    "label": "Alpha-phenylacetoacetonitrile (APAAN) (2926 4000)",
+    "value": "Alpha-phenylacetoacetonitrile (APAAN)",
+    "category": "1",
+    "cnCode": "2926 4000"
+  },
+  {
+    "label": "Chloroephedrine (2939 7990)",
+    "value": "Chloroephedrine",
+    "category": "1",
+    "cnCode": "2939 7990"
+  },
+  {
+    "label": "Chloropseudoephedrine (2939 7990)",
+    "value": "Chloropseudoephedrine",
+    "category": "1",
+    "cnCode": "2939 7990"
+  },
+  {
+    "label": "Ephedrine (2939 4100)",
+    "value": "Ephedrine",
+    "category": "1",
+    "cnCode": "2939 4100"
+  },
+  {
+    "label": "Ergometrine (2939 6100)",
+    "value": "Ergometrine",
+    "category": "1",
+    "cnCode": "2939 6100"
+  },
+  {
+    "label": "Ergotamine (2939 6200)",
+    "value": "Ergotamine",
+    "category": "1",
+    "cnCode": "2939 6200"
+  },
+  {
+    "label": "Isosafrole (2932 9100)",
+    "value": "Isosafrole",
+    "category": "1",
+    "cnCode": "2932 9100"
+  },
+  {
+    "label": "Lysergic Acid (2939 6300)",
+    "value": "Lysergic Acid",
+    "category": "1",
+    "cnCode": "2939 6300"
+  },
+  {
+    "label": "N-acetylanthranilic Acid (2924 2300)",
+    "value": "N-acetylanthranilic Acid",
+    "category": "1",
+    "cnCode": "2924 2300"
+  },
+  {
+    "label": "Norephedrine (2939 4400)",
+    "value": "Norephedrine",
+    "category": "1",
+    "cnCode": "2939 4400"
+  },
+  {
+    "label": "Piperonal (2932 9300)",
+    "value": "Piperonal",
+    "category": "1",
+    "cnCode": "2932 9300"
+  },
+  {
+    "label": "Pseudoephedrine (2939 4200)",
+    "value": "Pseudoephedrine",
+    "category": "1",
+    "cnCode": "2939 4200"
+  },
+  {
+    "label": "Safrole (2932 9400)",
+    "value": "Safrole",
+    "category": "1",
+    "cnCode": "2932 9400"
+  },
+  {
+    "label": "4-anilino-N-phenethylpiperidine (ANPP) (2933 3999)",
+    "value": "4-anilino-N-phenethylpiperidine (ANPP)",
+    "category": "1",
+    "cnCode": "2933 3999"
+  },
+  {
+    "label": "N-phenethyl-4-piperidone (NPP) (2933 3999)",
+    "value": "N-phenethyl-4-piperidone (NPP)",
+    "category": "1",
+    "cnCode": "2933 3999"
+  },
+  {
+    "label": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK methyl glycidate) (2932 9900)",
+    "value": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK methyl glycidate)",
+    "category": "1",
+    "cnCode": "2932 9900"
+  },
+  {
+    "label": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylic acid (PMK glycidic acid) (2932 9900)",
+    "value": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylic acid (PMK glycidic acid)",
+    "category": "1",
+    "cnCode": "2932 9900"
+  },
+  {
+    "label": "alpha-phenylacetoacetamide (APAA) (2924 2970)",
+    "value": "alpha-phenylacetoacetamide (APAA)",
+    "category": "1",
+    "cnCode": "2924 2970"
+  },
+  {
+    "label": "methyl alpha-phenylacetoacetate (MAPA) (2918 3000)",
+    "value": "methyl alpha-phenylacetoacetate (MAPA)",
+    "category": "1",
+    "cnCode": "2918 3000"
+  },
+  {
+    "label": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate) (2918 9990)",
+    "value": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate)",
+    "category": "1",
+    "cnCode": "2918 9990"
+  },
+  {
+    "label": "2‐methyl-3-phenyloxirane-2-carboxylic acid (BMK glycidic acid) (2918 9990)",
+    "value": "2‐methyl-3-phenyloxirane-2-carboxylic acid (BMK glycidic acid)",
+    "category": "1",
+    "cnCode": "2918 9990"
+  },
+  {
+    "label": "Acetic Anhydride (2915 2400)",
+    "value": "Acetic Anhydride",
+    "category": "2",
+    "cnCode": "2915 2400"
+  },
+  {
+    "label": "Red Phosphorous (2804 7000)",
+    "value": "Red Phosphorous",
+    "category": "2",
+    "cnCode": "2804 7000"
+  },
+  {
+    "label": "Phenylacetic Acid (2916 3400)",
+    "value": "Phenylacetic Acid",
+    "category": "2",
+    "cnCode": "2916 3400"
+  },
+  {
+    "label": "Potassium Permanganate (2841 6100)",
+    "value": "Potassium Permanganate",
+    "category": "2",
+    "cnCode": "2841 6100"
+  },
+  {
+    "label": "Anthranilic Acid (2922 4300)",
+    "value": "Anthranilic Acid",
+    "category": "2",
+    "cnCode": "2922 4300"
+  },
+  {
+    "label": "Piperidine (2933 3200)",
+    "value": "Piperidine",
+    "category": "2",
+    "cnCode": "2933 3200"
+  },
+  {
+    "label": "Acetone (2914 1100)",
+    "value": "Acetone",
+    "category": "3",
+    "cnCode": "2914 1100"
+  },
+  {
+    "label": "Ethyl Ether (2909 1100)",
+    "value": "Ethyl Ether",
+    "category": "3",
+    "cnCode": "2909 1100"
+  },
+  {
+    "label": "Hydrochloric Acid (2806 1000)",
+    "value": "Hydrochloric Acid",
+    "category": "3",
+    "cnCode": "2806 1000"
+  },
+  {
+    "label": "Methyl Ethyl Ketone (MEK) (2914 1200)",
+    "value": "Methyl Ethyl Ketone (MEK)",
+    "category": "3",
+    "cnCode": "2914 1200"
+  },
+  {
+    "label": "Sulphuric Acid (2807 0000)",
+    "value": "Sulphuric Acid",
+    "category": "3",
+    "cnCode": "2807 0000"
+  },
+  {
+    "label": "Toluene (2902 3000)",
+    "value": "Toluene",
+    "category": "3",
+    "cnCode": "2902 3000"
+  }
+]

--- a/apps/precursor-chemicals/data/chemicals.json
+++ b/apps/precursor-chemicals/data/chemicals.json
@@ -90,20 +90,20 @@
     "cnCode": "2932 9400"
   },
   {
-    "label": "4-anilino-N-phenethylpiperidine (ANPP) (2933 3999)",
-    "value": "4-anilino-N-phenethylpiperidine (ANPP)",
+    "label": "4-anilino-N-phenethylpiperidine/ ‘N-phenyl-1-(2 phe-nylethyl)piperidin-4-amine (ANPP) (2933 3600)",
+    "value": "4-anilino-N-phenethylpiperidine/ N-phenyl-1-(2 phe-nylethyl)piperidin-4-amine (ANPP)",
     "category": "1",
-    "cnCode": "2933 3999"
+    "cnCode": "2933 3600"
   },
   {
-    "label": "N-phenethyl-4-piperidone (NPP) (2933 3999)",
-    "value": "N-phenethyl-4-piperidone (NPP)",
+    "label": "N-phenethyl-4-piperidone/‘1-(2-phenylethyl)piperidin-4-one (NPP) (2933 3700)",
+    "value": "N-phenethyl-4-piperidone/1-(2-phenylethyl)piperidin-4-one (NPP)",
     "category": "1",
-    "cnCode": "2933 3999"
+    "cnCode": "2933 3700"
   },
   {
-    "label": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK methyl glycidate) (2932 9900)",
-    "value": "3-(1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK methyl glycidate)",
+    "label": "Methyl 3-(1,3-benzodioxol-5-yl)-2- methyloxirane-2-carboxylate (PMK methyl glycidate) (2932 9900)",
+    "value": "Methyl 3-(1,3-benzodioxol-5-yl)-2- methyloxirane-2-carboxylate (PMK methyl glycidate)",
     "category": "1",
     "cnCode": "2932 9900"
   },
@@ -114,28 +114,58 @@
     "cnCode": "2932 9900"
   },
   {
-    "label": "alpha-phenylacetoacetamide (APAA) (2924 2970)",
-    "value": "alpha-phenylacetoacetamide (APAA)",
+    "label": "Alpha-phenylacetoacetamide (APAA) (2924 2970)",
+    "value": "Alpha-phenylacetoacetamide (APAA)",
     "category": "1",
     "cnCode": "2924 2970"
   },
   {
-    "label": "methyl alpha-phenylacetoacetate (MAPA) (2918 3000)",
-    "value": "methyl alpha-phenylacetoacetate (MAPA)",
+    "label": "Methyl alpha-phenylacetoacetate (MAPA) (2918 3000)",
+    "value": "Methyl alpha-phenylacetoacetate (MAPA)",
     "category": "1",
     "cnCode": "2918 3000"
   },
   {
-    "label": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate) (2918 9990)",
-    "value": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate)",
+    "label": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glyci-date) (2918 9990)",
+    "value": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glyci-date)",
     "category": "1",
     "cnCode": "2918 9990"
   },
   {
-    "label": "2‐methyl-3-phenyloxirane-2-carboxylic acid (BMK glycidic acid) (2918 9990)",
-    "value": "2‐methyl-3-phenyloxirane-2-carboxylic acid (BMK glycidic acid)",
+    "label": "2‐methyl-3-phenyloxirane-2- carboxylic acid (BMK glycidic acid) (2918 9990)",
+    "value": "2‐methyl-3-phenyloxirane-2- carboxylic acid (BMK glycidic acid)",
     "category": "1",
     "cnCode": "2918 9990"
+  },
+  {
+    "label": "Diethyl (phenylacetyl) propanedioate (DEPAPD) * (2918 3000)",
+    "value": "Diethyl (phenylacetyl) propanedioate (DEPAPD)",
+    "category": "1",
+    "cnCode": "2918 3000"
+  },
+  {
+    "label": "Ethyl3-(2H-1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK ethyl glycidate) * (2932 9900)",
+    "value": "Ethyl3-(2H-1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK ethyl glycidate)",
+    "category": "1",
+    "cnCode": "2932 9900"
+  },
+  {
+    "label": "N-phenylpiperidin-4-amine (4-AP) * (2933 3999)",
+    "value": "N-phenylpiperidin-4-amine (4-AP)",
+    "category": "1",
+    "cnCode": "2933 3999"
+  },
+  {
+    "label": "Tert-butyl 4-anilinopiperidine-1-carboxylate (1-boc-4-AP) * (2933 3999)",
+    "value": "Tert-butyl 4-anilinopiperidine-1-carboxylate (1-boc-4-AP)",
+    "category": "1",
+    "cnCode": "2933 3999"
+  },
+  {
+    "label": "N-phenyl-N-(piperidin-4-yl)propenamide (norfentanyl) * (2933 3999)",
+    "value": "N-phenyl-N-(piperidin-4-yl)propenamide (norfentanyl)",
+    "category": "1",
+    "cnCode": "2933 3999"
   },
   {
     "label": "Acetic Anhydride (2915 2400)",
@@ -144,7 +174,7 @@
     "cnCode": "2915 2400"
   },
   {
-    "label": "Red Phosphorous (2804 7000)",
+    "label": "Red Phosphorous * (2804 7000)",
     "value": "Red Phosphorous",
     "category": "2",
     "cnCode": "2804 7000"

--- a/apps/precursor-chemicals/data/chemicals.json
+++ b/apps/precursor-chemicals/data/chemicals.json
@@ -90,8 +90,8 @@
     "cnCode": "2932 9400"
   },
   {
-    "label": "4-anilino-N-phenethylpiperidine/ ‘N-phenyl-1-(2 phe-nylethyl)piperidin-4-amine (ANPP) (2933 3600)",
-    "value": "4-anilino-N-phenethylpiperidine/ N-phenyl-1-(2 phe-nylethyl)piperidin-4-amine (ANPP)",
+    "label": "4-anilino-N-phenethylpiperidine/ ‘N-phenyl-1-(2 phenylethyl)piperidin-4-amine (ANPP) (2933 3600)",
+    "value": "4-anilino-N-phenethylpiperidine/ N-phenyl-1-(2 phenylethyl)piperidin-4-amine (ANPP)",
     "category": "1",
     "cnCode": "2933 3600"
   },
@@ -126,8 +126,8 @@
     "cnCode": "2918 3000"
   },
   {
-    "label": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glyci-date) (2918 9990)",
-    "value": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glyci-date)",
+    "label": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate) (2918 9990)",
+    "value": "Methyl 2-methyl-3-phenyloxirane-2-carboxylate (BMK methyl glycidate)",
     "category": "1",
     "cnCode": "2918 9990"
   },


### PR DESCRIPTION
## What? 
As a part of [CSL-26](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-26) - 1.6 PCA - Which category is the new substance? (About the licence)

This PR adds a new JSON file named `chemicals.json` that contains a list of chemicals. Each chemical entry includes the following fields:
- `label`: The name of the chemical along with its CN code.
- `value`: The name of the chemical.
- `category`: The category of the chemical.
- `cnCode`: The CN code of the chemical.

This file will be used to manage and reference chemicals within the application.

Source of the latest the chemicals list: https://www.gov.uk/guidance/precursor-chemical-licensing#categories

## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


