### PR TITLE
CSL-23: rename field for file upload

### DIFF
--- a/apps/precursor-chemicals/index.js
+++ b/apps/precursor-chemicals/index.js
@@ -176,7 +176,7 @@ const steps = {
       SaveDocument('company-registration-certificate', 'file-upload'),
       RemoveDocument('company-registration-certificate')
     ],
-    fields: ['upload-company-certificate']
+    fields: ['file-upload']
   },
 
   '/upload-conduct-certificate': {
@@ -185,7 +185,7 @@ const steps = {
       SaveDocument('certificate-of-good-conduct', 'file-upload'),
       RemoveDocument('certificate-of-good-conduct')
     ],
-    fields: ['upload-conduct-certificate']
+    fields: ['file-upload']
   },
 
   /** The organisation and how it operates */

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -166,21 +166,13 @@
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "You have exceeded the 2000 character limit"
   },
-  "upload-company-certificate": {
+  "file-upload": {
     "required": "Select a file",
     "unsaved": "The selected file was not uploaded – try again",
     "maxFileSize": "The selected files must be smaller than 25MB",
     "fileType": "The selected file must be a PNG, PDF, JPEG or Microsoft Word or Excel file",
     "virusCheck": "The file you have uploaded may have a virus. Please try a different file.",
     "companyRegistrationCertificateLimit" : "You may not add more than {{companyRegistrationCertificateLimit}} file(s)",
-    "isDuplicateFileName": "A file with this name was already uploaded"
-  },
-  "upload-conduct-certificate": {
-    "required": "Select a file",
-    "unsaved": "The selected file was not uploaded – try again",
-    "maxFileSize": "The selected files must be smaller than 25MB",
-    "fileType": "The selected file must be a PNG, PDF, JPEG or Microsoft Word or Excel file",
-    "virusCheck": "The file you have uploaded may have a virus. Please try a different file.",
     "certificateOfGoodConductLimit" : "You may not add more than {{certificateOfGoodConductLimit}} file(s)",
     "isDuplicateFileName": "A file with this name was already uploaded"
   },

--- a/apps/precursor-chemicals/views/upload-company-certificate.html
+++ b/apps/precursor-chemicals/views/upload-company-certificate.html
@@ -9,10 +9,10 @@
         {{#t}}fields.file-upload.label{{/t}}
     </label>
     <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
-      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.upload-company-certificate.maxFileSize{{/t}}
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
     </p>
     <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
-      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.upload-company-certificate.fileType{{/t}}
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
     </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="company-registration-certificate">
     <div id="upload-page-loading-spinner" class="spinner-container">

--- a/apps/precursor-chemicals/views/upload-conduct-certificate.html
+++ b/apps/precursor-chemicals/views/upload-conduct-certificate.html
@@ -9,10 +9,10 @@
         {{#t}}fields.file-upload.label{{/t}}
     </label>
     <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
-      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.upload-company-certificate.maxFileSize{{/t}}
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
     </p>
     <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
-      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.upload-company-certificate.fileType{{/t}}
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
     </p>
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="certificate-of-good-conduct">
     <div id="upload-page-loading-spinner" class="spinner-container">


### PR DESCRIPTION
## What? 
rename fields for file-upload in translations

## Why? 
so that it can be reused and to avoid confusion caused by references to non-existent fields.
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


