### PR TITLE
Update deploy.sh to fix file-vault certificate

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,19 +29,19 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
-  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
   $kd -f -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
-  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
   $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
-  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
   $kd -f kube/app/service.yml -f kube/app/ingress-external.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/deployment.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -25,18 +25,26 @@ export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/app -f kube/file-vault
+  $kd -f kube/redis -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis -f kube/app -f kube/file-vault
+  $kd -f kube/redis
+  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
+  $kd -f -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis -f kube/app -f kube/file-vault
+  $kd -f kube/redis
+  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
-  $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
-  $kd -f kube/file-vault
+  $kd -f kube/configmaps/configmap.yml
+  $kd -f kube/redis
+  $kd -f kube/file-vault/file-vault-ingress.yml -f kube/file-vault/file-vault-service.yml
+  $kd -f kube/file-vault/network-policy.yml -f kube/file-vault/deployment.yml
+  $kd -f kube/app/service.yml -f kube/app/ingress-external.yml
+  $kd -f kube/app/networkpolicy-external.yml -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY


### PR DESCRIPTION
Make file-vault deployments happen before app deployments Make file-vault ingresses run before file-vault deployments

## What?

Updated the order of processing kube resources by `kd` in `bin/deploy.sh`

## Why? 

- We wanted file-vault files to run before app files so that the pipeline will fail earlier that some config is failing before the app fully deploys.
- File-vault deployments are failing as the deployment resource tries to create the `file-vault-cert` as a volume before it is generated (or updated) by deploying first time changes to the `file-vault-ingress`. UAT builds will fail until resources are created in a useful order

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


