### PR TITLE
Update deploy.sh to fix syntax error

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -30,19 +30,19 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
   $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/file-vault/file-vault-network-policy.yml -f kube/file-vault/file-vault-deployment.yml
+  $kd -f kube/file-vault/file-vault-deployment.yml -f kube/file-vault/file-vault-network-policy.yml
   $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
   $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/file-vault/file-vault-network-policy.yml -f kube/file-vault/file-vault-deployment.yml
+  $kd -f kube/file-vault/file-vault-deployment.yml -f kube/file-vault/file-vault-network-policy.yml
   $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis
   $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
-  $kd -f kube/file-vault/file-vault-network-policy.yml -f kube/file-vault/file-vault-deployment.yml
+  $kd -f kube/file-vault/file-vault-deployment.yml -f kube/file-vault/file-vault-network-policy.yml
   $kd -f kube/app/service.yml -f kube/app/ingress-external.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/deployment.yml
 fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -31,7 +31,7 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/redis
   $kd -f kube/file-vault/file-vault-service.yml -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/file-vault/file-vault-network-policy.yml -f kube/file-vault/file-vault-deployment.yml
-  $kd -f -f kube/app
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/redis


### PR DESCRIPTION
## What? 
Removed extra `-f` option which cause failure on UAT environment
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)

Additionally update the order of processing kube resources by `kd` in `bin/deploy.sh`. 
Network Policies should be applied after the services and deployments to ensure that the they can reference existing resources

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


