### PR TITLE
Udate Production url

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: sas-csl-stg
   UAT_ENV: sas-csl-uat
   BRANCH_ENV: sas-csl-branch
-  PRODUCTION_URL: TBC
+  PRODUCTION_URL: www.licensing-for-controlled-substances.homeoffice.gov.uk
   IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/csl
   GIT_REPO: UKHomeOffice/controlled-substance-licence


### PR DESCRIPTION
## What? 
Updated deployment file to specify the production url `www.licensing-for-controlled-substances.homeoffice.gov.uk`
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


