### PR TITLE
CSL-26: Which category / which chemical (PC - About licence)

### DIFF
--- a/apps/precursor-chemicals/behaviours/filter-chemicals.js
+++ b/apps/precursor-chemicals/behaviours/filter-chemicals.js
@@ -1,7 +1,7 @@
 module.exports = superclass => class extends superclass {
   configure(req, res, next) {
     const chosenCategory = req.sessionModel.get('substance-category');
-    let options = req.form.options.fields['which-chemical'].options;
+    const options = req.form.options.fields['which-chemical'].options;
     if (chosenCategory !== 'unknown') {
       req.form.options.fields['which-chemical'].options = options.filter(
         option => !option.category || option.category === chosenCategory

--- a/apps/precursor-chemicals/behaviours/filter-chemicals.js
+++ b/apps/precursor-chemicals/behaviours/filter-chemicals.js
@@ -3,9 +3,10 @@ module.exports = superclass => class extends superclass {
     const chosenCategory = req.sessionModel.get('substance-category');
     let options = req.form.options.fields['which-chemical'].options;
     if (chosenCategory !== 'unknown') {
-      options = options.filter(option => !option.category || option.category === chosenCategory);
+      req.form.options.fields['which-chemical'].options = options.filter(
+        option => !option.category || option.category === chosenCategory
+      );
     }
-    req.form.options.fields['which-chemical'].options = options;
 
     next();
   }

--- a/apps/precursor-chemicals/behaviours/filter-chemicals.js
+++ b/apps/precursor-chemicals/behaviours/filter-chemicals.js
@@ -1,0 +1,16 @@
+const chemicals = require('../data/chemicals.json');
+
+module.exports = superclass => class extends superclass {
+  locals(req, res, next) {
+
+  const chosenCategory = req.sessionModel.get('substance-category');
+  const categoryChemicals = chemicals
+    .filter(chemical => chemical.category === chosenCategory)
+  const baseOptions = req.form.options.fields['which-chemical'].options;
+  req.form.options.fields['which-chemical'].options = baseOptions.concat(
+    chosenCategory !== 'unknown' ? categoryChemicals : chemicals
+  );
+
+  return super.locals(req, res, next);
+  }
+};

--- a/apps/precursor-chemicals/behaviours/filter-chemicals.js
+++ b/apps/precursor-chemicals/behaviours/filter-chemicals.js
@@ -1,16 +1,12 @@
-const chemicals = require('../data/chemicals.json');
-
 module.exports = superclass => class extends superclass {
-  locals(req, res, next) {
+  configure(req, res, next) {
+    const chosenCategory = req.sessionModel.get('substance-category');
+    let options = req.form.options.fields['which-chemical'].options;
+    if (chosenCategory !== 'unknown') {
+      options = options.filter(option => !option.category || option.category === chosenCategory);
+    }
+    req.form.options.fields['which-chemical'].options = options;
 
-  const chosenCategory = req.sessionModel.get('substance-category');
-  const categoryChemicals = chemicals
-    .filter(chemical => chemical.category === chosenCategory)
-  const baseOptions = req.form.options.fields['which-chemical'].options;
-  req.form.options.fields['which-chemical'].options = baseOptions.concat(
-    chosenCategory !== 'unknown' ? categoryChemicals : chemicals
-  );
-
-  return super.locals(req, res, next);
+    next();
   }
 };

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -1,4 +1,5 @@
 const dateComponent = require('hof').components.date;
+const chemicals = require('../data/chemicals.json');
 
 module.exports = {
   'company-name': {
@@ -286,7 +287,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.which-chemical.options.none_selected'
-    }]
+    }].concat(chemicals)
   },
   'chemicals-used-for': {
     isPageHeading: true,

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -256,6 +256,38 @@ module.exports = {
     validate: ['notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
+  'substance-category': {
+    isPageHeading: true,
+    mixin: 'radio-group',
+    validate: [ 'required' ],
+    options: [
+      {
+        value: '1'
+      },
+      {
+        value: '2'
+      },
+      {
+        value: '3'
+      },
+      {
+        value: 'unknown'
+      }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'which-chemical': {
+    isPageHeading: true,
+    mixin: 'select',
+    className: ['typeahead'],
+    validate: ['required'],
+    options: [{
+      value: '',
+      label: 'fields.which-chemical.options.none_selected'
+    }]
+  },
   'chemicals-used-for': {
     isPageHeading: true,
     mixin: 'textarea',

--- a/apps/precursor-chemicals/index.js
+++ b/apps/precursor-chemicals/index.js
@@ -3,6 +3,7 @@ const Summary = hof.components.summary;
 const customValidation = require('./behaviours/custom-validation');
 const SaveDocument = require('../common/behaviours/save-document');
 const RemoveDocument = require('../common/behaviours/remove-document');
+const FilterChemicals = require('./behaviours/filter-chemicals');
 
 const steps = {
 
@@ -140,10 +141,13 @@ const steps = {
   /** About the licence */
 
   '/substance-category': {
+    fields: ['substance-category'],
     next: '/which-chemical'
   },
 
   '/which-chemical': {
+    fields: ['which-chemical'],
+    behaviours: [FilterChemicals],
     next: '/which-operation'
   },
 

--- a/apps/precursor-chemicals/translations/src/en/fields.json
+++ b/apps/precursor-chemicals/translations/src/en/fields.json
@@ -153,6 +153,31 @@
   "invoicing-purchase-order-number": {
     "label": "Purchase order number (optional)"
   },
+  "substance-category": {
+    "legend": "Which category is the substance?",
+    "options": {
+      "1": {
+        "label": "Category 1"
+      },
+      "2": {
+        "label": "Category 2"
+      },
+      "3": {
+        "label": "Category 3"
+      },
+      "unknown": {
+        "label": "I do not know"
+      }
+    }
+  },
+  "which-chemical": {
+    "label": "Which chemical are you applying for?",
+    "options": {
+      "none_selected": {
+        "label": ""
+      }
+    }
+  },
   "chemicals-used-for": {
     "label": "Tell us why you need these chemicals and what they’ll be used for"
   },

--- a/apps/precursor-chemicals/translations/src/en/fields.json
+++ b/apps/precursor-chemicals/translations/src/en/fields.json
@@ -173,9 +173,7 @@
   "which-chemical": {
     "label": "Which chemical are you applying for?",
     "options": {
-      "none_selected": {
-        "label": ""
-      }
+      "none_selected": "Select a chemical"
     }
   },
   "chemicals-used-for": {

--- a/apps/precursor-chemicals/translations/src/en/pages.json
+++ b/apps/precursor-chemicals/translations/src/en/pages.json
@@ -32,7 +32,7 @@
   "guarantor-dbs-information": {
     "header": "Guarantor DBS information"
   },
- 
+
   "invoicing-address": {
     "header": "Invoicing address",
     "intro": "This is the address of your headquarters, and if you are registering as a limited company it must match your Companies House registered address."
@@ -40,14 +40,6 @@
 
   "invoicing-contact-details": {
     "header": "Invoicing contact details"
-  },
-
-  "substance-category": {
-    "header": "Which category is the new substance?"
-  },
-
-  "which-chemical": {
-    "header": "Which chemical are you applying for?"
   },
 
   "which-operation": {

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -161,6 +161,12 @@
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "Purchase order number must be between 1 and 250 characters"
   },
+  "substance-category": {
+    "required": "Select a category for the new substance"
+  },
+  "which-chemical": {
+    "required": "Enter which chemical you are applying for"
+  },
   "chemicals-used-for": {
     "required": "Enter details of the chemicals and what they will be used for",
     "notUrl": "Your answer must not contain URLs or links",

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -2,7 +2,15 @@
 'use strict';
 
 require('hof/frontend/themes/gov-uk/client-js');
+const accessibleAutocomplete = require('accessible-autocomplete');
 const config = require('../../config');
+
+document.querySelectorAll('.typeahead').forEach(function applyTypeahead(element) {
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: '',
+    selectElement: element
+  });
+});
 
 document.addEventListener('DOMContentLoaded', () => {
   const loaderContainer = document.querySelector('#loader-container');

--- a/assets/scss/_autocomplete.scss
+++ b/assets/scss/_autocomplete.scss
@@ -1,0 +1,143 @@
+// Accessible autocomplete
+.autocomplete__wrapper {
+  position: relative;
+}
+
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: 2px solid #0b0c0c;
+  border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
+  width: 100%;
+}
+
+.autocomplete__input {
+  background-color: transparent;
+  position: relative;
+}
+
+.autocomplete__hint {
+  color: #b1b4b6;
+  position: absolute;
+}
+
+.autocomplete__input--default {
+  padding: 5px;
+}
+
+.autocomplete__input--focused {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+
+.autocomplete__input--show-all-values {
+  padding: 5px 34px 5px 5px; /* Space for arrow. Other padding should match .autocomplete__input--default. */
+  cursor: pointer;
+}
+
+.autocomplete__dropdown-arrow-down{
+  z-index: -1;
+  display: inline-block;
+  position: absolute;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  top: 10px;
+}
+
+.autocomplete__menu {
+  background-color: #fff;
+  border: 2px solid #0B0C0C;
+  border-top: 0;
+  color: #0B0C0C;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0, 0, 0, 0.256863) 0px 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.autocomplete__menu--inline {
+  position: relative;
+}
+
+.autocomplete__option {
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+
+.autocomplete__option > * {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option--odd {
+  background-color: #FAFAFA;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: #1d70b8;
+  border-color: #1d70b8;
+  color: white;
+  outline: none;
+}
+
+.autocomplete__option--no-results {
+  background-color: #FAFAFA;
+  color: #646b6f;
+  cursor: not-allowed;
+}
+
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.autocomplete__hint,
+.autocomplete__option {
+  padding: 5px;
+}
+
+@media (min-width: 641px) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,3 +1,4 @@
+@use 'autocomplete';
 @use 'file-upload';
 
 @import "hof/frontend/themes/gov-uk/styles/govuk";

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/controlled-substance-licence#readme",
   "dependencies": {
+    "accessible-autocomplete": "^3.0.1",
     "bl": "^6.0.16",
     "busboy": "^1.6.0",
     "form-data": "^4.0.1",

--- a/test/unit/filter-chemicals.test.js
+++ b/test/unit/filter-chemicals.test.js
@@ -1,0 +1,90 @@
+const Behaviour = require('../../apps/precursor-chemicals/behaviours/filter-chemicals');
+const reqres = require('hof').utils.reqres;
+const chemicals = require('../../apps/precursor-chemicals/data/chemicals.json');
+
+describe('filter-chemicals behaviour', () => {
+  test('Behaviour exports a function', () => {
+    expect(typeof Behaviour).toBe('function');
+  });
+
+  class Base {
+    configure() {}
+  }
+
+  let req;
+  let res;
+  let instance;
+  let next;
+  let FilterChemicals;
+
+  // + 1 to include the none_selected option
+  const fullListLength = chemicals.length + 1;
+  const cat1Length = chemicals.filter(chem => chem.category === '1').length + 1;
+  const cat2Length = chemicals.filter(chem => chem.category === '2').length + 1;
+  const cat3Length = chemicals.filter(chem => chem.category === '3').length + 1;
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+    next = jest.fn();
+
+    FilterChemicals = Behaviour(Base);
+    instance = new FilterChemicals();
+  });
+
+  describe('The \'configure\' method', () => {
+    beforeEach(() => {
+      Base.prototype.configure = jest.fn().mockReturnValue(req, res, next);
+      req.sessionModel.set('substance-category', 'unknown');
+      req.form.options = {
+        fields: {
+          'which-chemical': {
+            options: [{
+              value: '',
+              label: 'Select a chemical'
+            }].concat(chemicals)
+          }
+        }
+      };
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('', () => {
+
+    });
+
+    test('next is called at the end of the behaviour', () => {
+      expect(next).toHaveBeenCalled;
+    });
+
+    test('session value for category is set as provided', () => {
+      expect(req.sessionModel.get('substance-category')).toBe('unknown');
+    });
+
+    test('if the category chosen was \'I do not know\' the full list of chemicals is available', () => {
+      instance.configure(req, res, next);
+      expect(req.form.options.fields['which-chemical'].options).toHaveLength(fullListLength);
+    });
+
+    test('if \'Category 1\' was chosen the list of chemicals to choose from is appropriately filtered', () => {
+      req.sessionModel.set('substance-category', '1');
+      instance.configure(req, res, next);
+      expect(req.form.options.fields['which-chemical'].options).toHaveLength(cat1Length);
+    });
+
+    test('if \'Category 2\' was chosen the list of chemicals to choose from is appropriately filtered', () => {
+      req.sessionModel.set('substance-category', '2');
+      instance.configure(req, res, next);
+      expect(req.form.options.fields['which-chemical'].options).toHaveLength(cat2Length);
+    });
+
+    test('if \'Category 3\' was chosen the list of chemicals to choose from is appropriately filtered', () => {
+      req.sessionModel.set('substance-category', '3');
+      instance.configure(req, res, next);
+      expect(req.form.options.fields['which-chemical'].options).toHaveLength(cat3Length);
+    });
+  });
+});

--- a/test/unit/filter-chemicals.test.js
+++ b/test/unit/filter-chemicals.test.js
@@ -52,10 +52,6 @@ describe('filter-chemicals behaviour', () => {
       jest.restoreAllMocks();
     });
 
-    test('', () => {
-
-    });
-
     test('next is called at the end of the behaviour', () => {
       expect(next).toHaveBeenCalled;
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,11 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+accessible-autocomplete@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz#8ddf4934d0b4ba6acb28de486dd505e062cdc86e"
+  integrity sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
## What?

Adding 'Which category is the substance?' and ''Which chemical are you applying for?' pages with filtering of available chemicals to select in 'which chemical' depending on 'which category' was chosen.

This is for Precursor chemicals 'About the licence' section.

## Why? 

[CSL-26](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-26)

## Testing?

Unit tests added

## Anything Else?

As these two pages will eventually be part of an aggregate loop with intermediate summary page it is expected that additional logic will be added to clear values and manage routing for these fields in subsequent tickets.

## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


