### PR TITLE
CSL-26: PCA updated chemicals list

### DIFF
--- a/apps/precursor-chemicals/data/chemicals.json
+++ b/apps/precursor-chemicals/data/chemicals.json
@@ -138,31 +138,31 @@
     "cnCode": "2918 9990"
   },
   {
-    "label": "Diethyl (phenylacetyl) propanedioate (DEPAPD) * (2918 3000)",
+    "label": "Diethyl (phenylacetyl) propanedioate (DEPAPD) (Northern Ireland only) (2918 3000)",
     "value": "Diethyl (phenylacetyl) propanedioate (DEPAPD)",
     "category": "1",
     "cnCode": "2918 3000"
   },
   {
-    "label": "Ethyl3-(2H-1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK ethyl glycidate) * (2932 9900)",
+    "label": "Ethyl3-(2H-1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK ethyl glycidate) (Northern Ireland only) (2932 9900)",
     "value": "Ethyl3-(2H-1,3-benzodioxol-5-yl)-2-methyloxirane-2-carboxylate (PMK ethyl glycidate)",
     "category": "1",
     "cnCode": "2932 9900"
   },
   {
-    "label": "N-phenylpiperidin-4-amine (4-AP) * (2933 3999)",
+    "label": "N-phenylpiperidin-4-amine (4-AP) (Northern Ireland only) (2933 3999)",
     "value": "N-phenylpiperidin-4-amine (4-AP)",
     "category": "1",
     "cnCode": "2933 3999"
   },
   {
-    "label": "Tert-butyl 4-anilinopiperidine-1-carboxylate (1-boc-4-AP) * (2933 3999)",
+    "label": "Tert-butyl 4-anilinopiperidine-1-carboxylate (1-boc-4-AP) (Northern Ireland only) (2933 3999)",
     "value": "Tert-butyl 4-anilinopiperidine-1-carboxylate (1-boc-4-AP)",
     "category": "1",
     "cnCode": "2933 3999"
   },
   {
-    "label": "N-phenyl-N-(piperidin-4-yl)propenamide (norfentanyl) * (2933 3999)",
+    "label": "N-phenyl-N-(piperidin-4-yl)propenamide (norfentanyl) (Northern Ireland only) (2933 3999)",
     "value": "N-phenyl-N-(piperidin-4-yl)propenamide (norfentanyl)",
     "category": "1",
     "cnCode": "2933 3999"
@@ -174,7 +174,7 @@
     "cnCode": "2915 2400"
   },
   {
-    "label": "Red Phosphorous * (2804 7000)",
+    "label": "Red Phosphorous (Northern Ireland only) (2804 7000)",
     "value": "Red Phosphorous",
     "category": "2",
     "cnCode": "2804 7000"

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -338,7 +338,7 @@ module.exports = {
   'what-operation': {
     mixin: 'input-text',
     isPageHeading: true,
-    validate: ['required', 'notUrl'],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'chemicals-used-for': {

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -173,7 +173,7 @@
   "what-operation": {
     "required": "Enter an operation",
     "notUrl": "Your answer must not contain URLs or links",
-    "maxlength": "Full name must be between 1 and 250 characters"
+    "maxlength": "Operation must be between 1 and 250 characters"
   },
   "chemicals-used-for": {
     "required": "Enter details of the chemicals and what they will be used for",


### PR DESCRIPTION
## What? 
Updated  chemicals list to replace `*` with `(Northern Ireland only)` for user reference
## Why? 
Some chemicals are only applicable to Northern Ireland, but there is no validation to prevent users from selecting such chemicals if they are registered elsewhere.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
- Updated maxlength validation for 'what-operation' field

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


