### PR TITLE
Testing RBAC on Keycloak resources from proxy config

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -149,7 +149,7 @@ spec:
             {{ end }}
           args:
             # URls that you wish to protect.
-            - --resources=uri=/*
+            - --resources="uri=/*|roles=application-approved"
             - --enable-default-deny=false
             - --enable-security-filter=true
             - --enable-request-id=true

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -149,7 +149,7 @@ spec:
             {{ end }}
           args:
             # URls that you wish to protect.
-            - --resources="uri=/*|roles=application-approved"
+            - --resources=uri=/*|roles=application-approved
             - --enable-default-deny=false
             - --enable-security-filter=true
             - --enable-request-id=true

--- a/utils/file-upload.js
+++ b/utils/file-upload.js
@@ -56,6 +56,7 @@ module.exports = class UploadModel extends Model {
 
       logger.info(`Received response from file-vault with keys: ${Object.keys(response)}`);
 
+      console.log('URL: ', response.url.replace('/file/', '/file/generate-link/').split('?')[0]);
       this.set({
         url: response.url.replace('/file/', '/file/generate-link/').split('?')[0]
       });
@@ -108,6 +109,8 @@ module.exports = class UploadModel extends Model {
       }
 
       logger.info('Successfully retrieved access token');
+
+      console.log('TOKEN: ', response.data.access_token);
       return {
         bearer: response.data.access_token
       };


### PR DESCRIPTION
## What?

Added role match requirement to file-vault resources on the Keycloak proxy to test what the current default behaviour would be in the case of authentication but not authorisation.
 
## How?

Add a privileged role to the requirements for passing the proxy.
Log some information that will help debug


