### PR TITLE
CSL-194 - PCA - Validation update on full name and DBS reference

### DIFF
--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -280,12 +280,12 @@ module.exports = {
   },
   'responsible-officer-dbs-application-fullname': {
     mixin: 'input-text',
-    validate: [ 'required', 'notUrl' ],
+    validate: [ 'required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'responsible-officer-dbs-reference': {
     mixin: 'input-text',
-    validate: [ 'required', 'notUrl' ],
+    validate: [ 'required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 25 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'responsible-officer-dbs-date-of-issue': dateComponent('responsible-officer-dbs-date-of-issue', {
@@ -319,7 +319,7 @@ module.exports = {
   },
   'guarantor-full-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'guarantor-email-address': {
@@ -333,12 +333,12 @@ module.exports = {
   },
   'guarantor-dbs-full-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'guarantor-dbs-reference': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 25 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'guarantor-dbs-date-of-issue': dateComponent('guarantor-dbs-date-of-issue', {
@@ -593,7 +593,7 @@ module.exports = {
   },
   'who-is-completing-application-full-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'who-is-completing-application-telephone': {

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -285,7 +285,13 @@ module.exports = {
   },
   'responsible-officer-dbs-reference': {
     mixin: 'input-text',
-    validate: [ 'required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 25 }],
+    validate: [
+      'required',
+      'notUrl',
+      'alphanum',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 25 }
+    ],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'responsible-officer-dbs-date-of-issue': dateComponent('responsible-officer-dbs-date-of-issue', {
@@ -338,7 +344,13 @@ module.exports = {
   },
   'guarantor-dbs-reference': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 25 }],
+    validate: [
+      'required',
+      'notUrl',
+      'alphanum',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 25 }
+    ],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'guarantor-dbs-date-of-issue': dateComponent('guarantor-dbs-date-of-issue', {

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -122,11 +122,15 @@
   },
   "responsible-officer-dbs-application-fullname": {
       "required": "Enter the name as it appears on the DBS certificate",
-      "notUrl": "Your answer must not contain URLs or links"
+      "notUrl": "Your answer must not contain URLs or links",
+      "maxlength": "Full name must be between 3 and 200 characters",
+      "minlength": "Full name must be between 3 and 200 characters"
   },
   "responsible-officer-dbs-reference": {
       "required": "Enter a DBS reference",
-      "notUrl": "Your answer must not contain URLs or links"
+      "notUrl": "Your answer must not contain URLs or links",
+      "maxlength": "DBS reference must be between 3 and 25 characters",
+      "minlength": "DBS reference must be between 3 and 25 characters"
   },
   "responsible-officer-dbs-date-of-issue": {
       "required": "Enter a date of issue or application",
@@ -139,7 +143,9 @@
   },
   "guarantor-full-name": {
     "required": "Enter guarantor’s name",
-    "notUrl": "Your answer must not contain URLs or links"
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Full name must be between 3 and 200 characters",
+    "minlength": "Full name must be between 3 and 200 characters"
   },
   "guarantor-email-address": {
     "required": "Enter an email address",
@@ -150,11 +156,15 @@
   },
   "guarantor-dbs-full-name": {
     "required": "Enter a name as it appears on the guarantor’s DBS certificate",
-    "notUrl": "Your answer must not contain URLs or links"
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Full name must be between 3 and 200 characters",
+    "minlength": "Full name must be between 3 and 200 characters"
   },
   "guarantor-dbs-reference": {
     "required": "Enter a DBS reference",
-    "notUrl": "Your answer must not contain URLs or links"
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "DBS reference must be between 3 and 25 characters",
+    "minlength": "DBS reference must be between 3 and 25 characters"
   },
   "guarantor-dbs-date-of-issue": {
     "required": "Enter a date of issue or application",
@@ -279,7 +289,8 @@
   "who-is-completing-application-full-name": {
     "required": "Enter a full name",
     "notUrl": "Your answer must not contain URLs or links",
-    "maxlength": "Full name must be between 1 and 250 characters"
+    "maxlength": "Full name must be between 3 and 200 characters",
+    "minlength": "Full name must be between 3 and 200 characters"
   },
   "who-is-completing-application-telephone": {
     "required": "Enter a UK telephone number",

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -130,7 +130,8 @@
       "required": "Enter a DBS reference",
       "notUrl": "Your answer must not contain URLs or links",
       "maxlength": "DBS reference must be between 3 and 25 characters",
-      "minlength": "DBS reference must be between 3 and 25 characters"
+      "minlength": "DBS reference must be between 3 and 25 characters",
+      "alphanum": "Enter a real DBS certificate number or application reference number"
   },
   "responsible-officer-dbs-date-of-issue": {
       "required": "Enter a date of issue or application",
@@ -164,7 +165,8 @@
     "required": "Enter a DBS reference",
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "DBS reference must be between 3 and 25 characters",
-    "minlength": "DBS reference must be between 3 and 25 characters"
+    "minlength": "DBS reference must be between 3 and 25 characters",
+    "alphanum": "Enter a real DBS certificate number or application reference number"
   },
   "guarantor-dbs-date-of-issue": {
     "required": "Enter a date of issue or application",


### PR DESCRIPTION
## What? 

[CSL-194](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-194) -  A change request to update and synchronise the validation rules for the full name and DBS reference fields across both PCA and CD forms


## How? 
- Added additional validation for min and max length on these fields
- updated the error message in validation.json

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


