### PR TITLE
CSL-96: amend forking from step 'status-of-site'

### DIFF
--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -506,13 +506,14 @@ const steps = {
     fields: ['status-of-site'],
     forks: [
       {
-        target: '/site-owner-contact-details',
-        condition: req => (
-          req.form.values['status-of-site'] === 'rented' || req.form.values['status-of-site'] === 'leased'
-        )
+        target: '/licence-details',
+        condition: {
+          field: 'status-of-site',
+          value: 'owned-or-owner-occupied'
+        }
       }
     ],
-    next: '/licence-details'
+    next: '/site-owner-contact-details'
   },
 
   '/site-owner-contact-details': {

--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -504,7 +504,15 @@ const steps = {
 
   '/status-of-site': {
     fields: ['status-of-site'],
-    next: '/site-owner-contact-details'
+    forks: [
+      {
+        target: '/site-owner-contact-details',
+        condition: req => (
+          req.form.values['status-of-site'] === 'rented' || req.form.values['status-of-site'] === 'leased'
+        )
+      }
+    ],
+    next: '/licence-details'
   },
 
   '/site-owner-contact-details': {


### PR DESCRIPTION
## What? 

Add a fork from the end of 'status-of-site' page dependent on the radio option selected in that form

## Why? 

This was missed in the main PR and raised by QAT

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


