### PR TITLE
CSL-139: Add internal ingress to dataservice deployment

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,6 +5,7 @@ export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yam
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
+export DATA_SERVICE_INTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-internal-annotations.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
 

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: data-service-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: data-service
+  {{ end }}
+{{ file .DATA_SERVICE_INTERNAL_ANNOTATIONS | indent 2 }}
+spec:
+  ingressClassName: nginx-internal
+  tls:
+    - hosts:
+      {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
+        - csl-data-service.internal.sas.homeoffice.gov.uk
+      {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+        - csl-data-service.internal.stg.sas.homeoffice.gov.uk
+      {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+        - csl-data-service.internal.uat.sas-notprod.homeoffice.gov.uk
+      {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+        - data-service-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+      {{ end }}
+      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+      secretName: branch-tls-internal
+      {{ else }}
+      secretName: data-service-cert-cmio
+      {{ end }}
+  rules:
+    {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
+    - host: csl-data-service.internal.sas.homeoffice.gov.uk
+    {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+    - host: csl-data-service.internal.stg.sas.homeoffice.gov.uk
+    {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+    - host: csl-data-service.internal.uat.sas-notprod.homeoffice.gov.uk
+    {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+    - host: data-service-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
+    {{ end }}
+      http:
+        paths:
+          - path: /
+            backend:
+              {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+              serviceName: data-service-{{ .DRONE_SOURCE_BRANCH }}
+              {{ else }}
+              serviceName: data-service
+              {{ end }}
+              servicePort: 10443


### PR DESCRIPTION
## What? 

* Internal Ingress to be deployed and configured as part of CI/CD
* Internal ingress annotations are added to hof-services-config
* Certs are added to the namespaces manually needs to be automated
* Internal ingress is required in order to rotate and replace certs 

## Why? 
* We are using Common Names/ FQDN in Secrets and certs. 
* Hence decided to deploy Internal Ingress to avoid issues

## How? 
* Add the internal ingress for data service and ensure we deploy it via CI/CD ( automated) 
* Ensure the certs and secrets are using the same Common name/ FQDN aligning to the ingress urls used

## Testing?

* We will need to test the annotations configured to the ingress during drone build

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


