### PR TITLE
CSL-202: forking logic to skip /company-registration-certificate step

### DIFF
--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -293,6 +293,7 @@ const steps = {
 
   '/witness-destruction-of-drugs': {
     fields: ['require-witness-destruction-of-drugs'],
+    // The conditional check should be performed in reverse order, as the last fork takes over.
     forks: [
       {
         target: '/trading-reasons',
@@ -300,6 +301,11 @@ const steps = {
           field: 'require-witness-destruction-of-drugs',
           value: 'no'
         }
+      },
+      {
+        target: '/company-registration-certificate',
+        condition: req => req.sessionModel.get('licensee-type') !== 'existing-licensee-renew-or-change-site' &&
+          req.sessionModel.get('require-witness-destruction-of-drugs') === 'no'
       }
     ],
     next: '/who-witnesses-destruction-of-drugs',
@@ -317,6 +323,11 @@ const steps = {
           field: 'responsible-for-witnessing-the-destruction',
           value: 'someone-else'
         }
+      },
+      {
+        target: '/company-registration-certificate',
+        condition: req => req.sessionModel.get('licensee-type') !== 'existing-licensee-renew-or-change-site' &&
+          req.sessionModel.get('responsible-for-witnessing-the-destruction') === 'same-as-managing-director'  
       }
     ],
     next: '/trading-reasons'
@@ -350,8 +361,7 @@ const steps = {
     forks: [
       {
         target: '/company-registration-certificate',
-        condition: req => req.sessionModel.get('licensee-type') === 'first-time-licensee' ||
-          req.sessionModel.get('licensee-type') === 'existing-licensee-applying-for-new-site'
+        condition: req => req.sessionModel.get('licensee-type') !== 'existing-licensee-renew-or-change-site'
       }
     ],
     template: 'person-in-charge-dbs-updates'

--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -327,7 +327,7 @@ const steps = {
       {
         target: '/company-registration-certificate',
         condition: req => req.sessionModel.get('licensee-type') !== 'existing-licensee-renew-or-change-site' &&
-          req.sessionModel.get('responsible-for-witnessing-the-destruction') === 'same-as-managing-director'  
+          req.sessionModel.get('responsible-for-witnessing-the-destruction') === 'same-as-managing-director'
       }
     ],
     next: '/trading-reasons'


### PR DESCRIPTION
## What? 
[CSL-202](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-202)
TICKET TO REFLECT AMENDMENT TO PAGE DESIGN - Do you require somebody within your company to be authorised to witness the destruction of controlled drugs & Who is responsible for witnessing the destruction of controlled drugs

## Why? 
to cover scenarios where user should be redirected to '/company-registration-certificate' step, unless user is an Existing licensee renewing or changing a currently licensed site.

User will be redirected to `/company-registration-certificate` step, if on step`/witness-destruction-of-drugs` answer is 'No' or if on step `/who-witnesses-destruction-of-drugs` answer is 'The same'

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


