### PR TITLE
CSL-113: Add custom redirect around /register-again step

### DIFF
--- a/apps/controlled-drugs/behaviours/custom-redirect.js
+++ b/apps/controlled-drugs/behaviours/custom-redirect.js
@@ -95,6 +95,12 @@ const checkServiceDetails = (req, currentRoute, action) => (
   !!req.sessionModel.get('service-expiry-date')
 );
 
+// Handle routing around /company-number-changed and /register-again
+const checkCompaniesHouseRef = (req, currentRoute) => (
+  currentRoute === '/company-number-changed' &&
+  req.form.values['companies-house-number-change'] === 'yes'
+)
+
 module.exports = superclass => class extends superclass {
   successHandler(req, res, next) {
     const { route: currentRoute, confirmStep } = req.form.options;
@@ -102,6 +108,10 @@ module.exports = superclass => class extends superclass {
     const formApp = req.baseUrl;
 
     this.emit('complete', req, res);
+
+    if (checkCompaniesHouseRef(req, currentRoute)) {
+      return res.redirect(`${formApp}/register-again`);
+    }
 
     const shouldRedirectToConfirmStep = [
       req.sessionModel.get('referred-by-summary'),

--- a/apps/controlled-drugs/behaviours/custom-redirect.js
+++ b/apps/controlled-drugs/behaviours/custom-redirect.js
@@ -99,7 +99,7 @@ const checkServiceDetails = (req, currentRoute, action) => (
 const checkCompaniesHouseRef = (req, currentRoute) => (
   currentRoute === '/company-number-changed' &&
   req.form.values['companies-house-number-change'] === 'yes'
-)
+);
 
 module.exports = superclass => class extends superclass {
   successHandler(req, res, next) {

--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -60,19 +60,12 @@ const steps = {
 
   '/company-number-changed': {
     fields: ['companies-house-number-change'],
-    forks: [
-      {
-        target: '/company-name-changed',
-        condition: {
-          field: 'companies-house-number-change',
-          value: 'no'
-        }
-      }
-    ],
-    next: '/register-again'
+    next: '/company-name-changed',
+    behaviours: [SetSummaryReferrer, CustomRedirect]
   },
 
   '/register-again': {
+    backLink: '/controlled-drugs/company-number-changed'
   },
 
   '/company-name-changed': {

--- a/apps/precursor-chemicals/behaviours/custom-redirect.js
+++ b/apps/precursor-chemicals/behaviours/custom-redirect.js
@@ -1,9 +1,19 @@
+// Handle routing around /companies-house-number and /cannot-continue
+const checkCompaniesHouseRef = (req, currentRoute) => (
+  currentRoute === '/companies-house-number' &&
+  req.form.values['companies-house-number-change'] === 'yes'
+);
+
 module.exports = superclass => class extends superclass {
   successHandler(req, res, next) {
     const formApp = req.baseUrl;
-    const confirmStep = req.form.options.confirmStep;
+    const { route: currentRoute, confirmStep } = req.form.options;
 
     this.emit('complete', req, res);
+
+    if (checkCompaniesHouseRef(req, currentRoute)) {
+      return res.redirect(`${formApp}/cannot-continue`);
+    }
 
     if(req.sessionModel.get('referred-by-summary')) {
       return res.redirect(`${formApp}${confirmStep}`);

--- a/apps/precursor-chemicals/index.js
+++ b/apps/precursor-chemicals/index.js
@@ -61,16 +61,8 @@ const steps = {
 
   '/companies-house-number': {
     fields: ['companies-house-number-change'],
-    forks: [
-      {
-        target: '/companies-house-name',
-        condition: {
-          field: 'companies-house-number-change',
-          value: 'no'
-        }
-      }
-    ],
-    next: '/cannot-continue'
+    next: '/companies-house-name',
+    behaviours: [SetSummaryReferrer, CustomRedirect]
   },
 
   '/companies-house-name': {
@@ -88,6 +80,7 @@ const steps = {
   },
 
   '/cannot-continue': {
+    backLink: '/precursor-chemicals/companies-house-number'
   },
 
   '/upload-companies-house-evidence': {


### PR DESCRIPTION
## What? 

Added custom redirect from /company-number-changed to /register-again and removed classic HOF forking as a result of issues reported in comments in [CSL-113](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-113)

Added `SetSummaryReferrer` and `CustomRedirect` behaviours as there is derivation from the 'edit' action.

## Why? 

When changing the yes/no answer in /company-number-changed **after** reaching the summary and receiving the /register-again page as a result HOF was losing several steps and values from the session, causing the user to have to fill the form again from near the start and eventually errors in resolving summary data sections.

It was unclear exactly what was causing this - possibly as a result of reaching the end of a fork journey, or possibly due to not being able to resolve steps back into the right shape when walking back on the above action.

## How?

Moved redirection to the /register-again page into the CD custom-redirect behaviour. This stops HOF mismanaging the step change and allows normal and post summary routing to behave as intended

## Anything Else? (optional)

**Made the equivalent change also for precursor-chemicals form, as the flow setup was identical and the same issue exists**

If further issues are found around this section of the form it could be argued that there is no need to show a question in the summary where altering the answer would immediately end the form journey.

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


