### PR TITLE
[CSL 156 THC] add page for how are you applying for your low THC cannibis…

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -1,6 +1,53 @@
-
 module.exports = {
-
+  'application-form-type': {
+    mixin: 'radio-group',
+    isPageHeading: 'true',
+    validate: ['required'],
+    options: [
+      {
+        value: 'new-application'
+      },
+      {
+        value: 'continue-an-application'
+      },
+      {
+        value: 'amend-application',
+        toggle: 'amend-application-details',
+        child: 'input-text'
+      }
+    ]
+  },
+  'amend-application-details': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      'numeric',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 8 }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    dependent: {
+      value: 'amend-application',
+      field: 'application-form-type'
+    }
+  },
+  'licensee-type': {
+    mixin: 'radio-group',
+    isPageHeading: 'true',
+    validate: ['required'],
+    options: [
+      {
+        value: 'first-time-licensee'
+      },
+      {
+        value: 'existing-licensee-renew-or-change-site'
+      },
+      {
+        value: 'existing-licensee-applying-for-new-site'
+      }
+    ]
+  },
   'company-name': {
     mixin: 'input-text',
     validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -1,4 +1,5 @@
 const hof = require('hof');
+
 const Summary = hof.components.summary;
 const customValidation = require('../common/behaviours/custom-validation');
 
@@ -7,12 +8,39 @@ const steps = {
   /** Start of journey */
 
   '/application-type': {
+    fields: ['application-form-type', 'amend-application-details'],
+    forks: [
+      {
+        target: '/information-you-have-given-us',
+        condition: {
+          field: 'application-form-type',
+          value: 'continue-an-application'
+        }
+      }
+    ],
     next: '/licensee-type',
     backLink: '/licence-type'
   },
 
   '/licensee-type': {
-    next: '/confirm'
+    fields: ['licensee-type'],
+    next: '/licence-holder-details',
+    forks: [
+      {
+        target: '/company-number-changed',
+        condition: {
+          field: 'licensee-type',
+          value: 'existing-licensee-renew-or-change-site'
+        }
+      },
+      {
+        target: '/why-new-licence',
+        condition: {
+          field: 'licensee-type',
+          value: 'existing-licensee-applying-for-new-site'
+        }
+      }
+    ]
   },
 
   '/licence-holder-details': {

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -1,6 +1,14 @@
 'use strict';
 
 module.exports = {
+  'background-information': {
+    steps: [
+      {
+        step: '/application-type',
+        field: 'amend-application-details'
+      }
+    ]
+  },
   'about-the-applicants': {
     steps: [
       {

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -1,4 +1,37 @@
 {
+  "application-form-type": {
+    "legend": "How are you applying for your low THC cannabis license?",
+    "options": {
+      "new-application": {
+        "label": "A new application"
+      },
+      "continue-an-application": {
+        "label": "Continue an application",
+        "hint": "An incomplete application stays on the system for 5 days and is then deleted"
+      },
+      "amend-application": {
+        "label": "Amend pending application"
+      }
+    }
+  },
+  "amend-application-details": {
+    "label": "Application reference number",
+    "hint": "For example, 12345678"
+  },
+  "licensee-type": {
+    "legend": "What type of low THC cannabis licensee are you?",
+    "options": {
+      "first-time-licensee": {
+        "label": "A first time licensee"
+      },
+      "existing-licensee-renew-or-change-site": {
+        "label": "Existing licensee renewing or changing a currently licensed site"
+      },
+      "existing-licensee-applying-for-new-site": {
+        "label": "Existing licensee applying for a new site"
+      }
+    }
+  },
   "company-name": {
     "label": "Company name"
   },

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -17,9 +17,15 @@
     "sections": {
       "about-the-applicants": {
         "header": "About the applicants"
+      },
+      "background-information": {
+        "header": "Background information"
       }
     },
     "fields": {
+      "amend-application-details": {
+        "label": "Application reference number"
+      },
       "licence-holder-details": {
         "label": "Licence holder details"
       },

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -1,5 +1,16 @@
 {
-
+  "application-form-type": {
+    "required": "Select how would you like to apply"
+  },
+  "amend-application-details": {
+    "required": "Reference number provided must be between 2 and 8 numeral digits",
+    "numeric": "Reference number provided must be between 2 and 8 numeral digits",
+    "minlength": "Reference number provided must be between 2 and 8 numeral digits",
+    "maxlength": "Reference number provided must be between 2 and 8 numeral digits"
+  },
+  "licensee-type": {
+    "required": "Select what type of licensee are you"
+  },
   "company-name": {
     "required": "Enter a company name",
     "notUrl": "Your answer must not contain URLs or links",

--- a/apps/industrial-hemp/views/application-type.html
+++ b/apps/industrial-hemp/views/application-type.html
@@ -1,0 +1,7 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#renderField}}application-form-type{{/renderField}}
+    {{#markdown}}company-registration-details{{/markdown}}
+    {{#input-submit}}continue{{/input-submit}} 
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/industrial-hemp/views/content/en/company-registration-details.md
+++ b/apps/industrial-hemp/views/content/en/company-registration-details.md
@@ -1,0 +1,10 @@
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      How can I amend my company registration details
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">Email <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a> to amend company registration details.</p>
+  </div>
+</details>


### PR DESCRIPTION
## What? 
Added the How are you applying for your low THC cannabis licence & What type of low THC cannabis licensee are you? pages. See ticket [CSL-156](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-156)
## Why? 
As per business requirement
## How? 
- Added the application-form-type and amend-application-details fields and licensee-type fields in the fields/index.js
- Added the routes for the two pages
- Added custom behaviour to enable redirects from the /licensee-type page
- Added views and partials directory
- Added a partial html page for the toggle input in the /application-type page
- Added a html page for the /application-type page to add click to open details element
## Testing?
Manual developer test for the html pages and added a unit test for the custom behaviour.
## Screenshots (optional)
![Screenshot 2025-03-07 at 14 44 49](https://github.com/user-attachments/assets/ac26c6b6-570d-4d44-bbf9-4a1c878afd6a)
![Screenshot 2025-03-07 at 14 45 42](https://github.com/user-attachments/assets/a60a674d-72ca-40b2-bb06-ade7ee8b93d1)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


