### PR TITLE
[CSL 145 THC] Add License Holder details pages

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -1,3 +1,50 @@
 
 module.exports = {
+
+  'company-name': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'company-number': {
+    mixin: 'input-text',
+    validate: [], // additional validation rules added in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  telephone: {
+    mixin: 'input-text',
+    validate: ['required'], // additional validation covered in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  email: {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'website-url': {
+    mixin: 'input-text',
+    validate: ['url', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-address-line-1': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-address-line-2': {
+    mixin: 'input-text',
+    validate: ['notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-town-or-city': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-postcode': {
+    mixin: 'input-text',
+    validate: ['required', 'postcode'],
+    formatter: ['ukPostcode'],
+    className: ['govuk-input', 'govuk-input--width-10']
+  }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -37,6 +37,11 @@ const steps = {
     ],
     next: '/reuse-premises-address'
   },
+
+  '/reuse-premises-address': {
+    next: '/confirm'
+  },
+
   /** Continue an application */
 
 

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -1,5 +1,6 @@
 const hof = require('hof');
 const Summary = hof.components.summary;
+const customValidation = require('../common/behaviours/custom-validation');
 
 const steps = {
 
@@ -14,6 +15,28 @@ const steps = {
     next: '/confirm'
   },
 
+  '/licence-holder-details': {
+    behaviours: [customValidation],
+    fields: [
+      'company-name',
+      'company-number',
+      'telephone',
+      'email',
+      'website-url'
+    ],
+    next: '/licence-holder-address',
+    backLink: '/application-type'
+  },
+
+  '/licence-holder-address': {
+    fields: [
+      'licence-holder-address-line-1',
+      'licence-holder-address-line-2',
+      'licence-holder-town-or-city',
+      'licence-holder-postcode'
+    ],
+    next: '/reuse-premises-address'
+  },
   /** Continue an application */
 
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -1,5 +1,43 @@
 'use strict';
 
-module.exports = {
+/**
+ * Parses a list of 0 or more checkbox options from a 'checkbox-group' field.
+ *
+ * @param {array|string} list - The checked box option(s). This is string for one checked and array for more than one
+ * @param {object} req - The request object
+ * @returns {string} - A string of the list items separated by a newline or the value of journey.not-provided.
+ */
 
+module.exports = {
+  'about-the-applicants': {
+    steps: [
+      {
+        step: '/licence-holder-details',
+        field: 'licence-holder-details',
+        parse: (list, req) => {
+          const licenseHolderDetails = [
+            req.sessionModel.get('company-name'),
+            req.sessionModel.get('company-number').toUpperCase(),
+            req.sessionModel.get('website-url'),
+            req.sessionModel.get('telephone'),
+            req.sessionModel.get('email')
+          ];
+          return licenseHolderDetails.filter(element => element).join('\n');
+        }
+      },
+      {
+        step: '/licence-holder-address',
+        field: 'licence-holder-address',
+        parse: (list, req) => {
+          const licenceHolderAddress = [
+            req.sessionModel.get('licence-holder-address-line-1'),
+            req.sessionModel.get('licence-holder-address-line-2'),
+            req.sessionModel.get('licence-holder-town-or-city'),
+            req.sessionModel.get('licence-holder-postcode')
+          ];
+          return licenceHolderAddress.filter(element => element).join('\n');
+        }
+      }
+    ]
+  }
 };

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -1,13 +1,5 @@
 'use strict';
 
-/**
- * Parses a list of 0 or more checkbox options from a 'checkbox-group' field.
- *
- * @param {array|string} list - The checked box option(s). This is string for one checked and array for more than one
- * @param {object} req - The request object
- * @returns {string} - A string of the list items separated by a newline or the value of journey.not-provided.
- */
-
 module.exports = {
   'about-the-applicants': {
     steps: [

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -1,3 +1,30 @@
 {
-  
+  "company-name": {
+    "label": "Company name"
+  },
+  "company-number": {
+    "label": "Company number (optional)",
+    "hint": "Enter the  number issued by Companies House"
+  },
+  "telephone": {
+    "label": "UK telephone number"
+  },
+  "email": {
+    "label": "Email address"
+  },
+  "website-url": {
+    "label": "Website URL (optional)"
+  },
+  "licence-holder-address-line-1": {
+    "label": "Address line 1"
+  },
+  "licence-holder-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "licence-holder-town-or-city": {
+    "label": "Town or city"
+  },
+  "licence-holder-postcode": {
+    "label": "Postcode"
+  }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -5,5 +5,15 @@
   "licence-holder-address": {
     "header": "Licence holder address",
     "intro": "This is the address your business is registered at."
+  },
+  "confirm": {
+    "fields": {
+      "licence-holder-details": {
+        "label": "Licence holder details"
+      },
+      "licence-holder-address": {
+        "label": "Licence holder address"
+      }
+    }
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -7,6 +7,12 @@
     "intro": "This is the address your business is registered at."
   },
   "confirm": {
+    "header": "Check your answers",
+    "sections": {
+      "about-the-applicants": {
+        "header": "About the applicants"
+      }
+    },
     "fields": {
       "licence-holder-details": {
         "label": "Licence holder details"

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -1,3 +1,9 @@
 {
-
+  "licence-holder-details": {
+    "header": "Licence holder details"
+  },
+  "licence-holder-address": {
+    "header": "Licence holder address",
+    "intro": "This is the address your business is registered at."
+  }
 }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -1,3 +1,43 @@
 {
+
+  "company-name": {
+    "required": "Enter a company name",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Company name must be between 2 and 200 characters",
+    "minlength": "Company name must be between 2 and 200 characters"
+  },
+  "company-number": {
+    "companyNumber": "Enter a real company number, like 16850062"
+  },
+  "telephone": {
+    "required": "Enter a UK telephone number",
+    "ukPhoneNumber": "Enter a UK telephone number in the correct format, like 01632 960001 or +44 808 157 0192"
+  },
+  "email": {
+    "required": "Enter an email address",
+    "email": "Enter a real email address"
+  },
+  "website-url": {
+    "url": "Enter a real website URL",
+    "maxlength": "Website URL must be between 1 and 250 characters"
+  },
+  "licence-holder-address-line-1": {
+    "required": "Enter a licence holder address",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 1 must be between 1 and 250 characters"
+  },
+  "licence-holder-address-line-2": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 2 must be between 1 and 250 characters"
+  },
+  "licence-holder-town-or-city": {
+    "required": "Enter a town or city",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Town or city must be between 1 and 250 characters"
+  },
+  "licence-holder-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a real UK postcode"
+  }
   
 }


### PR DESCRIPTION
## What? 
Added the license holder details and license holder address pages for your low THC journey See ticket [CSL-145](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-145)
## Why? 
As per business requirement
## How? 
- Added the license-holder-details and licence-holder-address fields in the fields/index.js
- Added the routes for the two pages
- Added the relevant validation messages
## Testing?
Manual developer test for the html pages. 
## Screenshots (optional)
![Screenshot 2025-03-10 at 12 39 59](https://github.com/user-attachments/assets/0d831e08-b63d-4853-886f-c6bb17f87f2a)
![Screenshot 2025-03-10 at 11 46 14](https://github.com/user-attachments/assets/e6abb1c1-49d7-448f-af75-799d40881a43)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)



