### PR TITLE
[CSL-159-THC] add details page for person responsible for the site

### DIFF
--- a/apps/common/behaviours/custom-validation.js
+++ b/apps/common/behaviours/custom-validation.js
@@ -16,7 +16,8 @@ module.exports = superclass => class extends superclass {
 
     if (key === 'telephone' || key === 'premises-telephone' ||
       key === 'invoicing-telephone' || key === 'who-is-completing-application-telephone' ||
-      key === 'growing-location-uk-telephone') {
+      key === 'growing-location-uk-telephone' ||
+      key === 'site-responsible-person-uk-telephone') {
       const phoneNumber = req.form.values[key];
       if (phoneNumber) {
         if (!isValidPhoneNumber(phoneNumber) || !validators.ukPhoneNumber(phoneNumber)) {

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -66,6 +66,7 @@ module.exports = {
   email: {
     mixin: 'input-text',
     validate: ['required', 'email'],
+    type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'website-url': {
@@ -118,6 +119,7 @@ module.exports = {
   'growing-location-email': {
     mixin: 'input-text',
     validate: ['email'],
+    type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
 
@@ -147,6 +149,7 @@ module.exports = {
   'site-responsible-person-email': {
     mixin: 'input-text',
     validate: ['required', 'email'],
+    type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
 

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -118,7 +118,6 @@ module.exports = {
   'growing-location-email': {
     mixin: 'input-text',
     validate: ['email'],
-    type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
 
@@ -148,7 +147,6 @@ module.exports = {
   'site-responsible-person-email': {
     mixin: 'input-text',
     validate: ['required', 'email'],
-    type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
 

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -126,6 +126,35 @@ module.exports = {
     mixin: 'input-text',
     validate: ['required'], // additional validation covered in custom-validation.js
     className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+
+  'site-responsible-person-full-name': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: [3] },
+      { type: 'maxlength', arguments: [200] }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+
+  'site-responsible-person-uk-telephone': {
+    mixin: 'input-text',
+    validate: ['required'], // additional validation covered in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+
+  'site-responsible-person-email': {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    type: 'email',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+
+  'site-responsible-DBS-check': {
+    mixin: 'checkbox',
+    validate: ['required']
   }
 
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -52,7 +52,7 @@ const steps = {
       'email',
       'website-url'
     ],
-    next: '/licence-holder-address',
+    next: '/licence-holder-address'
   },
 
   '/licence-holder-address': {

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -53,7 +53,6 @@ const steps = {
       'website-url'
     ],
     next: '/licence-holder-address',
-    backLink: '/application-type'
   },
 
   '/licence-holder-address': {

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -84,7 +84,19 @@ const steps = {
     ],
     next: '/site-responsible-officer'
   },
+
   '/site-responsible-officer': {
+    behaviours: [customValidation],
+    fields: [
+      'site-responsible-person-full-name',
+      'site-responsible-person-uk-telephone',
+      'site-responsible-person-email',
+      'site-responsible-DBS-check'
+    ],
+    next: '/site-responsible-officer-dbs'
+  },
+
+  '/site-responsible-officer-dbs': {
     next: '/confirm'
   },
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -61,6 +61,18 @@ module.exports = {
           ];
           return growingLocationContact.filter(element => element).join('\n');
         }
+      },
+      {
+        step: '/site-responsible-officer',
+        field: 'site-responsible-officer',
+        parse: (list, req) => {
+          const siteResponsibleOfficerDetails = [
+            req.sessionModel.get('site-responsible-person-full-name'),
+            req.sessionModel.get('site-responsible-person-uk-telephone'),
+            req.sessionModel.get('site-responsible-person-email')
+          ];
+          return siteResponsibleOfficerDetails.filter(element => element).join('\n');
+        }
       }
     ]
   }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -60,25 +60,37 @@
   "licence-holder-postcode": {
     "label": "Postcode"
   },
-    "growing-location-address-line-1": {
-        "label": "Address line 1"
-    },
-    "growing-location-address-line-2": {
-        "label": "Address line 2 (optional)"
-    },
-    "growing-location-town-or-city": {
-        "label": "Town or city"
-    },
-    "growing-location-postcode": {
-        "label": "Postcode"
-    },
-    "growing-location-email": {
-        "label": "Email address (optional)"
-    },
-    "growing-location-uk-telephone": {
-        "label": "UK telephone number"
-    },
-    "premises-email": {
-        "label": "Email address (optional)"
-    }
+  "growing-location-address-line-1": {
+    "label": "Address line 1"
+  },
+  "growing-location-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "growing-location-town-or-city": {
+    "label": "Town or city"
+  },
+  "growing-location-postcode": {
+    "label": "Postcode"
+  },
+  "growing-location-email": {
+    "label": "Email address (optional)"
+  },
+  "growing-location-uk-telephone": {
+    "label": "UK telephone number"
+  },
+  "premises-email": {
+    "label": "Email address (optional)"
+  },
+  "site-responsible-person-full-name": {
+    "label": "Full name"
+  },
+  "site-responsible-person-uk-telephone": {
+    "label": "UK telephone number"
+  },
+  "site-responsible-person-email": {
+    "label": "Email address"
+  },
+  "site-responsible-DBS-check": {
+    "label": "I confirm this person has applied for or currently holds a DBS certificate"
+  }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -12,6 +12,9 @@
   "growing-location-contact": {
     "header": "Growing location contact details"
   },
+  "site-responsible-officer": {
+    "header": "Details of the responsible person for the site"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {
@@ -37,6 +40,9 @@
       },
       "growing-location-contact": {
         "label": "Growing location contact details"
+      },
+      "site-responsible-officer": {
+        "label": "Responsible person details"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -74,5 +74,22 @@
   "growing-location-uk-telephone": {
     "required": "Enter a UK telephone number",
     "ukPhoneNumber": "Enter a UK telephone number in the correct format, like 01632 960001 or +44 808 157 0192"
+  },
+  "site-responsible-person-full-name": {
+    "required": "Enter the name of the responsible person for the site",
+    "notUrl": "Your answer must not contain URLs or links",
+    "minlength": "Full name must be between 3 and 200 characters",
+    "maxlength": "Full name must be between 3 and 200 characters"
+  },
+  "site-responsible-person-uk-telephone": {
+    "required": "Enter a UK telephone number",
+    "ukPhoneNumber": "Enter a UK telephone number in the correct format, like 01632 960001 or +44 808 157 0192"
+  },
+  "site-responsible-person-email": {
+    "required": "Enter an email address",
+    "email": "Enter a real email address"
+  },
+  "site-responsible-DBS-check": {
+    "required": "You must confirm this person has applied for or currently holds a DBS certificate"
   }
 }


### PR DESCRIPTION
## What? 
Added details of the person for the site page. 
## Why? 
As per business requirements
## How? 
Added name, email, uk phone and DBS checkbox fields for the added details of the person for the site page
## Testing?
Manual developer test conducted
## Screenshots (optional)
![Screenshot 2025-03-13 at 16 25 06](https://github.com/user-attachments/assets/be571ee5-0832-4b7c-9821-2ee00770a894)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


