### PR TITLE
[CSL-158-THC] add DBS information for person responsible pages

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -1,3 +1,5 @@
+const dateComponent = require('hof').components.date;
+
 module.exports = {
   'application-form-type': {
     mixin: 'radio-group',
@@ -122,13 +124,11 @@ module.exports = {
     type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
-
   'growing-location-uk-telephone': {
     mixin: 'input-text',
     validate: ['required'], // additional validation covered in custom-validation.js
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
-
   'site-responsible-person-full-name': {
     mixin: 'input-text',
     validate: [
@@ -139,23 +139,68 @@ module.exports = {
     ],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
-
   'site-responsible-person-uk-telephone': {
     mixin: 'input-text',
     validate: ['required'], // additional validation covered in custom-validation.js
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
-
   'site-responsible-person-email': {
     mixin: 'input-text',
     validate: ['required', 'email'],
     type: 'email',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
-
   'site-responsible-DBS-check': {
     mixin: 'checkbox',
     validate: ['required']
+  },
+  'responsible-person-dbs-fullname': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 200 }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'responsible-person-dbs-reference': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 25 },
+      'alphanum'
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'responsible-person-dbs-date-of-issue': dateComponent('responsible-person-dbs-date-of-issue', {
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date',
+      { type: 'before', arguments: ['0', 'days'] },
+      { type: 'after', arguments: ['3', 'years'] }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-4'
+    }
+  }),
+  'responsible-officer-dbs-updates': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   }
-
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -96,6 +96,20 @@ const steps = {
   },
 
   '/site-responsible-officer-dbs': {
+    fields: [
+      'responsible-person-dbs-fullname',
+      'responsible-person-dbs-reference',
+      'responsible-person-dbs-date-of-issue'
+    ],
+    next: '/site-responsible-officer-dbs-updates'
+  },
+
+  '/site-responsible-officer-dbs-updates': {
+    fields: ['responsible-officer-dbs-updates'],
+    next: '/witness-destruction-plant'
+  },
+
+  '/witness-destruction-plant': {
     next: '/confirm'
   },
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -1,4 +1,5 @@
 'use strict';
+const { formatDate } = require('../../../utils');
 
 module.exports = {
   'background-information': {
@@ -73,7 +74,24 @@ module.exports = {
           ];
           return siteResponsibleOfficerDetails.filter(element => element).join('\n');
         }
+      },
+      {
+        step: '/site-responsible-officer-dbs',
+        field: 'site-responsible-officer-dbs-information',
+        parse: (list, req) => {
+          const responsiblePersonDbsInfo = [
+            req.sessionModel.get('responsible-person-dbs-fullname'),
+            req.sessionModel.get('responsible-person-dbs-reference'),
+            formatDate(req.sessionModel.get('responsible-person-dbs-date-of-issue'))
+          ];
+          return responsiblePersonDbsInfo.filter(element => element).join('\n');
+        }
+      },
+      {
+        step: '/site-responsible-officer-dbs-updates',
+        field: 'responsible-officer-dbs-updates'
       }
+
     ]
   }
 };

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -92,5 +92,26 @@
   },
   "site-responsible-DBS-check": {
     "label": "I confirm this person has applied for or currently holds a DBS certificate"
+  },
+  "responsible-person-dbs-fullname": {
+    "label": "Full name",
+    "hint": "Enter the name as it appears on their DBS application"
+  },
+  "responsible-person-dbs-reference": {
+    "label": "DBS reference"
+  },
+  "responsible-person-dbs-date-of-issue": {
+    "label": "Date of issue or application"
+  },
+  "responsible-officer-dbs-updates": {
+    "legend": "Has the responsible person subscribed to DBS updates?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -15,6 +15,9 @@
   "site-responsible-officer": {
     "header": "Details of the responsible person for the site"
   },
+  "site-responsible-officer-dbs": {
+    "header": "DBS information for the responsible person"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {
@@ -43,6 +46,12 @@
       },
       "site-responsible-officer": {
         "label": "Responsible person details"
+      },
+      "site-responsible-officer-dbs-information": {
+        "label": "Responsible person DBS information"
+      },
+      "responsible-officer-dbs-updates": {
+        "label": "Authorised witness subscribed to DBS updates?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -111,6 +111,6 @@
     "after": "DBS certificates cannot be more than 3 years old. This person must apply for a new DBS certificate"
   },
   "responsible-officer-dbs-updates": {
-    "required": "Select if the person in charge has subscribed to DBS updates"
+    "required": "Select if the responsible person has subscribed to DBS updates"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -91,5 +91,26 @@
   },
   "site-responsible-DBS-check": {
     "required": "You must confirm this person has applied for or currently holds a DBS certificate"
+  },
+  "responsible-person-dbs-fullname": {
+    "required": "Enter the name of the responsible person as it appears on the DBS certificate",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Full name must be between 3 and 200 characters",
+    "minlength": "Full name must be between 3 and 200 characters"
+  },
+  "responsible-person-dbs-reference": {
+    "required": "Enter a DBS reference, for example a certificate number or an application reference number",
+    "maxlength": "DBS reference must be between 3 and 25 characters",
+    "minlength": "DBS reference must be between 3 and 25 characters",
+    "alphanum": "Enter a real DBS certificate number or application reference number"
+  },
+  "responsible-person-dbs-date-of-issue": {
+    "required": "Enter the DBS date of issue or application for the responsible person",
+    "date": "Enter a real date of issue or application",
+    "before": "DBS date of issue or application must not be in the future",
+    "after": "DBS certificates cannot be more than 3 years old. This person must apply for a new DBS certificate"
+  },
+  "responsible-officer-dbs-updates": {
+    "required": "Select if the person in charge has subscribed to DBS updates"
   }
 }

--- a/apps/industrial-hemp/views/content/en/dbs-updates-warning.md
+++ b/apps/industrial-hemp/views/content/en/dbs-updates-warning.md
@@ -1,8 +1,4 @@
-<div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-visually-hidden">Warning</span>
-    If yes, they must email <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a> 
-    with their date of birth, DBS reference number, issue date and explicit consent for the Drugs and Firearms Licensing Unit to access this service
-  </strong>
-</div>
+<span>
+If yes, they must email <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a> 
+with their date of birth, DBS reference number, issue date and explicit consent for the Drugs and Firearms Licensing Unit to access this service
+</span>

--- a/apps/industrial-hemp/views/content/en/dbs-updates-warning.md
+++ b/apps/industrial-hemp/views/content/en/dbs-updates-warning.md
@@ -1,0 +1,8 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">Warning</span>
+    If yes, they must email <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a> 
+    with their date of birth, DBS reference number, issue date and explicit consent for the Drugs and Firearms Licensing Unit to access this service
+  </strong>
+</div>

--- a/apps/industrial-hemp/views/partials/warning-dbs-subscription-responsible-officer.html
+++ b/apps/industrial-hemp/views/partials/warning-dbs-subscription-responsible-officer.html
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">{{#t}}journey.warning{{/t}}</span>
+    {{#markdown}}dbs-updates-warning.md{{/markdown}}
+  </strong>
+</div>

--- a/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
+++ b/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
@@ -1,0 +1,7 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#renderField}}responsible-officer-dbs-updates{{/renderField}}
+    {{#markdown}}dbs-updates-warning.md{{/markdown}}
+    {{#input-submit}}continue{{/input-submit}} 
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
+++ b/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
@@ -1,7 +1,7 @@
 {{<partials-page}}
   {{$page-content}}
     {{#renderField}}responsible-officer-dbs-updates{{/renderField}}
-    {{#markdown}}dbs-updates-warning.md{{/markdown}}
+    {{> partials-warning-dbs-responsible-officer}}
     {{#input-submit}}continue{{/input-submit}} 
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
## What? 
Added two pages for the section of  DBS information for the person responsible for the site. See ticket [CSL-158](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-158)
## Why? 
As per business requirements
## How? 
- Added the new fields for the DBS information section
- Added the validations and routes to reach the new pages
- Updated the summary-data-section.js file to include the new field data in the summary page
- Added a Markdown file which contains the warning component for the DBS updates page
## Testing?
Manual developer test conducted
## Screenshots (optional)
![Screenshot 2025-03-14 at 15 43 11](https://github.com/user-attachments/assets/97de0312-03cd-4f2c-aa04-58a5c9a13cc3)
![Screenshot 2025-03-14 at 16 15 32](https://github.com/user-attachments/assets/017adc6d-b256-48de-a944-8a1980cc9d36)


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


