### PR TITLE
[CSL-158] fixed typo in partials file for site-responsible-officer-db…

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -186,7 +186,7 @@ module.exports = {
       className: 'govuk-!-margin-bottom-4'
     }
   }),
-  'responsible-officer-dbs-updates': {
+  'responsible-officer-dbs-subscription': {
     mixin: 'radio-group',
     isPageHeading: true,
     validate: [ 'required' ],

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -105,7 +105,7 @@ const steps = {
   },
 
   '/site-responsible-officer-dbs-updates': {
-    fields: ['responsible-officer-dbs-updates'],
+    fields: ['responsible-officer-dbs-subscription'],
     next: '/witness-destruction-plant'
   },
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -89,7 +89,7 @@ module.exports = {
       },
       {
         step: '/site-responsible-officer-dbs-updates',
-        field: 'responsible-officer-dbs-updates'
+        field: 'responsible-officer-dbs-subscription'
       }
 
     ]

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -103,7 +103,7 @@
   "responsible-person-dbs-date-of-issue": {
     "label": "Date of issue or application"
   },
-  "responsible-officer-dbs-updates": {
+  "responsible-officer-dbs-subscription": {
     "legend": "Has the responsible person subscribed to DBS updates?",
     "options": {
       "yes": {

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -50,7 +50,7 @@
       "site-responsible-officer-dbs-information": {
         "label": "Responsible person DBS information"
       },
-      "responsible-officer-dbs-updates": {
+      "responsible-officer-dbs-subscription": {
         "label": "Authorised witness subscribed to DBS updates?"
       }
     }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -110,7 +110,7 @@
     "before": "DBS date of issue or application must not be in the future",
     "after": "DBS certificates cannot be more than 3 years old. This person must apply for a new DBS certificate"
   },
-  "responsible-officer-dbs-updates": {
+  "responsible-officer-dbs-subscription": {
     "required": "Select if the responsible person has subscribed to DBS updates"
   }
 }

--- a/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
+++ b/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
@@ -1,7 +1,7 @@
 {{<partials-page}}
   {{$page-content}}
-    {{#renderField}}responsible-officer-dbs-updates{{/renderField}}
-    {{> partials-warning-dbs-responsible-officer}}
+    {{#renderField}}responsible-officer-dbs-subscription{{/renderField}}
+    {{> partials-warning-dbs-subscription-responsible-officer}}
     {{#input-submit}}continue{{/input-submit}} 
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
## What? 
Fixed typo in partials file for site responsible officer dbs updates page. This is coming from the following ticket [CSL-158](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-158)
## Why? 
This is causing a routing error on UAT
## How? 
By fixing the typo in the site-responsible-officer-dbs-updates.html page. 
## Testing?
Manual test
## Screenshots (optional)
![image](https://github.com/user-attachments/assets/ad3c9e54-a4ca-4e1e-a4a1-ad10cd465ba3)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


