### PR TITLE
[CSL 164 THC] add new pages for authorised witness destruction of the plant

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -202,5 +202,28 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
+  },
+  'witness-destruction-plant': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'how-leaves-flowers-destroyed': {
+    mixin: 'textarea',
+    isPageHeading: true,
+    validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }],
   }
 };

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -224,6 +224,6 @@ module.exports = {
     mixin: 'textarea',
     isPageHeading: true,
     validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
-    attributes: [{ attribute: 'rows', value: 8 }],
+    attributes: [{ attribute: 'rows', value: 8 }]
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -110,6 +110,35 @@ const steps = {
   },
 
   '/witness-destruction-plant': {
+    fields: ['witness-destruction-plant'],
+    next: '/how-leaves-flowers-destroyed'
+  },
+
+  '/how-leaves-flowers-destroyed': {
+    fields: ['how-leaves-flowers-destroyed'],
+    forks: [
+      {
+        target: '/authorised-witness-details',
+        condition: {
+          field: 'witness-destruction-plant',
+          value: 'yes'
+        }
+      },
+      {
+        target: '/legal-business-proceedings',
+        condition: {
+          field: 'witness-destruction-plant',
+          value: 'no'
+        }
+      }
+    ]
+  },
+
+  '/authorised-witness-details': {
+    next: '/confirm'
+  },
+
+  '/legal-business-proceedings': {
     next: '/confirm'
   },
 

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -116,19 +116,13 @@ const steps = {
 
   '/how-leaves-flowers-destroyed': {
     fields: ['how-leaves-flowers-destroyed'],
+    next: '/legal-business-proceedings',
     forks: [
       {
         target: '/authorised-witness-details',
         condition: {
           field: 'witness-destruction-plant',
           value: 'yes'
-        }
-      },
-      {
-        target: '/legal-business-proceedings',
-        condition: {
-          field: 'witness-destruction-plant',
-          value: 'no'
         }
       }
     ]

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -98,7 +98,7 @@ module.exports = {
       {
         step: '/how-leaves-flowers-destroyed',
         field: 'how-leaves-flowers-destroyed'
-      },
+      }
 
     ]
   }

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -90,7 +90,15 @@ module.exports = {
       {
         step: '/site-responsible-officer-dbs-updates',
         field: 'responsible-officer-dbs-subscription'
-      }
+      },
+      {
+        step: '/witness-destruction-plant',
+        field: 'witness-destruction-plant'
+      },
+      {
+        step: '/how-leaves-flowers-destroyed',
+        field: 'how-leaves-flowers-destroyed'
+      },
 
     ]
   }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -113,5 +113,21 @@
         "label": "No"
       }
     }
+  },
+  "witness-destruction-plant": {
+    "legend": "Do you require somebody within your company to be authorised to witness the destruction of the plant?",
+    "hint": "This includes the controlled parts of the plant (leaves and flowers)",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "how-leaves-flowers-destroyed": {
+    "label": "How will the leaves and flowers be destroyed?",
+    "hint": "Providing a detailed description will help us process your application faster"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -51,7 +51,13 @@
         "label": "Responsible person DBS information"
       },
       "responsible-officer-dbs-subscription": {
-        "label": "Authorised witness subscribed to DBS updates?"
+        "label": "Responsible person subscribed to DBS updates?"
+      },
+      "witness-destruction-plant": {
+        "label": "Require somebody to be authorised to witness the destruction of the plant?"
+      },
+      "how-leaves-flowers-destroyed": {
+        "label": "How will the leaves and flowers be destroyed?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -117,6 +117,8 @@
     "required": "Select if you need someone to be authorised to witness the destruction of the plant"
   },
   "how-leaves-flowers-destroyed": {
-    "required": "Enter how the leaves and flowers will be destroyed"
+    "required": "Enter how the leaves and flowers will be destroyed",
+    "maxlength": "Details of how the leaves and flowers will be destroyed must be 2,000 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -112,5 +112,11 @@
   },
   "responsible-officer-dbs-subscription": {
     "required": "Select if the responsible person has subscribed to DBS updates"
+  },
+  "witness-destruction-plant": {
+    "required": "Select if you need someone to be authorised to witness the destruction of the plant"
+  },
+  "how-leaves-flowers-destroyed": {
+    "required": "Enter how the leaves and flowers will be destroyed"
   }
 }


### PR DESCRIPTION
## What? 
Added two new pages for the witness of destruction of the plant section. Please see ticket [CSL-164](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-164). Also updated the summary label for the responsible-officer-dbs-subscription. This is for the following ticket [CSL-158](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-158)
## Why? 
As per business requirements
## How? 
- Added new fields for the destruction of plant section
- Added the new routes for these two pages
- Updated the summary page content to take into account these new fields
- Added a fork for the /how-leaves-flowers-destroyed page based on the answer chosen in /witness-destruction-plant plant
- Updated the summary label for the responsible-officer-dbs-subscription field
## Testing?
Manual developer test conducted
## Screenshots (optional)
![Screenshot 2025-03-20 at 10 21 21](https://github.com/user-attachments/assets/fa2aa1bb-270e-40db-9511-ed58d2405673)
![Screenshot 2025-03-20 at 10 20 49](https://github.com/user-attachments/assets/52b6fc17-5d2a-4b62-adcb-8f05d852bcfd)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


