### PR TITLE
CSL - 167 - THC - Added legal proceedings and criminal conviction pages in LTHCC

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -298,5 +298,45 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
+  },
+  'legal-business-proceedings': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'legal-business-proceedings-details': {
+    mixin: 'textarea',
+    isPageHeading: true,
+    validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }]
+  },
+  'has-anyone-received-criminal-conviction': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -43,6 +43,8 @@ const steps = {
     ]
   },
 
+  /** First time licensee - About the applicants */
+
   '/licence-holder-details': {
     behaviours: [customValidation],
     fields: [
@@ -150,10 +152,35 @@ const steps = {
 
   '/authorised-witness-dbs-updates': {
     fields: ['authorised-witness-dbs-subscription'],
-    next: '/confirm'
+    next: '/legal-business-proceedings',
+    template: 'site-responsible-officer-dbs-updates'
   },
 
   '/legal-business-proceedings': {
+    fields: ['legal-business-proceedings'],
+    forks: [
+      {
+        target: '/legal-business-proceedings-details',
+        condition: {
+          field: 'legal-business-proceedings',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/criminal-conviction'
+  },
+
+  '/legal-business-proceedings-details': {
+    fields: ['legal-business-proceedings-details'],
+    next: '/criminal-conviction'
+  },
+
+  '/criminal-conviction': {
+    fields: ['has-anyone-received-criminal-conviction'],
+    next: '/other-regulatory-licences'
+  },
+
+  '/other-regulatory-licences': {
     next: '/confirm'
   },
 
@@ -164,9 +191,6 @@ const steps = {
 
 
   /** Existing licence apply for new site - Background Information */
-
-
-  /** First time licensee - About the applicants */
 
   '/confirm': {
     behaviours: [Summary],

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -4,7 +4,6 @@ const Summary = hof.components.summary;
 const customValidation = require('../common/behaviours/custom-validation');
 
 const steps = {
- 
   /** Start of journey */
 
   '/application-type': {

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -127,8 +127,19 @@ module.exports = {
       {
         step: '/authorised-witness-dbs-updates',
         field: 'authorised-witness-dbs-subscription'
+      },
+      {
+        step: '/legal-business-proceedings',
+        field: 'legal-business-proceedings'
+      },
+      {
+        step: '/legal-business-proceedings-details',
+        field: 'legal-business-proceedings-details'
+      },
+      {
+        step: '/criminal-conviction',
+        field: 'has-anyone-received-criminal-conviction'
       }
-
     ]
   }
 };

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -162,5 +162,32 @@
         "label": "No"
       }
     }
+  },
+  "legal-business-proceedings": {
+    "legend": "Has anyone in your organisation ever been subject to legal business proceedings?",
+    "hint": "This includes members of the board and senior management teams. Legal proceedings includes administrative, financial or bankruptcy cases",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "legal-business-proceedings-details": {
+    "label": "Provide details of the legal business proceedings"
+  },
+  "has-anyone-received-criminal-conviction": {
+    "legend": "Has anyone in your organisation ever received a criminal conviction?",
+    "hint": "This includes members of the board and senior management teams. Conviction means UK and overseas convictions.",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -74,6 +74,15 @@
       },
       "authorised-witness-dbs-subscription": {
         "label": "Authorised witness subscribed to DBS updates?"
+      },
+      "legal-business-proceedings": {
+        "label": "Has anyone been subject to legal proceedings?"
+      },
+      "legal-business-proceedings-details": {
+        "label": "Details of legal business proceedings"
+      },
+      "has-anyone-received-criminal-conviction": {
+        "label": "Has anyone ever received a criminal conviction?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -158,5 +158,16 @@
   },
   "authorised-witness-dbs-subscription": {
     "required": "Select if the authorised witness has subscribed to DBS updates"
+  },
+  "legal-business-proceedings": {
+    "required": "Select if anyone has ever been subject to legal business proceedings"
+  },
+  "legal-business-proceedings-details": {
+    "required": "Provide details of the legal business proceedings",
+    "maxlength": "Details of legal business proceedings must be 2,000 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
+  },
+  "has-anyone-received-criminal-conviction": {
+    "required": "Select if anyone in your organisation has ever received a criminal conviction"
   }
 }

--- a/apps/industrial-hemp/views/authorised-witness-dbs-updates.html
+++ b/apps/industrial-hemp/views/authorised-witness-dbs-updates.html
@@ -1,7 +1,0 @@
-{{<partials-page}}
-  {{$page-content}}
-    {{#renderField}}authorised-witness-dbs-subscription{{/renderField}}
-    {{> partials-warning-dbs-subscription}}
-    {{#input-submit}}continue{{/input-submit}} 
-  {{/page-content}}
-{{/partials-page}}

--- a/apps/industrial-hemp/views/content/en/received-criminal-conviction-instructions.md
+++ b/apps/industrial-hemp/views/content/en/received-criminal-conviction-instructions.md
@@ -1,0 +1,3 @@
+<span>
+If you answered ‘Yes’, you must email <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a> with details of the person and their conviction after submitting this form
+</span>

--- a/apps/industrial-hemp/views/criminal-conviction.html
+++ b/apps/industrial-hemp/views/criminal-conviction.html
@@ -1,0 +1,7 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#renderField}}has-anyone-received-criminal-conviction{{/renderField}}
+    {{> partials-warning-received-criminal-conviction}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/industrial-hemp/views/partials/warning-received-criminal-conviction.html
+++ b/apps/industrial-hemp/views/partials/warning-received-criminal-conviction.html
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">{{#t}}journey.warning{{/t}}</span>
+        {{#markdown}}received-criminal-conviction-instructions{{/markdown}}
+    </strong>
+</div>

--- a/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
+++ b/apps/industrial-hemp/views/site-responsible-officer-dbs-updates.html
@@ -1,6 +1,8 @@
 {{<partials-page}}
   {{$page-content}}
-    {{#renderField}}responsible-officer-dbs-subscription{{/renderField}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
     {{> partials-warning-dbs-subscription}}
     {{#input-submit}}continue{{/input-submit}} 
   {{/page-content}}


### PR DESCRIPTION
## What? 

[CSL-167](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-167) -  Added pages for /legal-business-proceedings, /legal-business-proceeding-details, and /criminal-conviction


## How? 
- Added necessary step configuration and field specific variables. 
- Added required field validation for all pages

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


