### PR TITLE
CSL- REG -129-licence-details

### DIFF
--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -1,4 +1,54 @@
 
 module.exports = {
-
+  'company-name': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'name-of-responsible-person': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'company-number': {
+    mixin: 'input-text',
+    validate: [], // additional validation rules added in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  telephone: {
+    mixin: 'input-text',
+    validate: ['required'], // additional validation covered in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  email: {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'website-url': {
+    mixin: 'input-text',
+    validate: ['url', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-address-line-1': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-address-line-2': {
+    mixin: 'input-text',
+    validate: ['notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-town-or-city': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'licence-holder-postcode': {
+    mixin: 'input-text',
+    validate: ['required', 'postcode'],
+    formatter: ['ukPostcode'],
+    className: ['govuk-input', 'govuk-input--width-10']
+  }
 };

--- a/apps/registration/index.js
+++ b/apps/registration/index.js
@@ -1,5 +1,6 @@
 const hof = require('hof');
 const Summary = hof.components.summary;
+const customValidation = require('../common/behaviours/custom-validation');
 
 const steps = {
 
@@ -9,6 +10,29 @@ const steps = {
   },
 
   '/licence-holder-details': {
+    behaviours: [customValidation],
+    fields: [
+      'company-name',
+      'name-of-responsible-person',
+      'company-number',
+      'telephone',
+      'email',
+      'website-url'
+    ],
+    next: '/licence-holder-address'
+  },
+
+  '/licence-holder-address': {
+    fields: [
+      'licence-holder-address-line-1',
+      'licence-holder-address-line-2',
+      'licence-holder-town-or-city',
+      'licence-holder-postcode'
+    ],
+    next: '/reuse-premises-address'
+  },
+
+  '/reuse-premises-address': {
     next: '/confirm'
   },
 

--- a/apps/registration/sections/summary-data-sections.js
+++ b/apps/registration/sections/summary-data-sections.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    'licence-holder-details': {
+  'licence-holder-details': {
     steps: [
       {
         step: '/licence-holder-details',

--- a/apps/registration/sections/summary-data-sections.js
+++ b/apps/registration/sections/summary-data-sections.js
@@ -14,7 +14,7 @@ module.exports = {
       {
         step: '/licence-holder-details',
         field: 'company-number',
-        parse: value => value.toUpperCase() || 'Not Provided'
+        parse: (value, req) => value.toUpperCase() || req.translate('journey.not-provided')
       },
       {
         step: '/licence-holder-details',
@@ -27,7 +27,7 @@ module.exports = {
       {
         step: '/licence-holder-details',
         field: 'website-url',
-        parse: value => value || 'Not Provided'
+        parse: (value, req) => value || req.translate('journey.not-provided')
       }
     ]
   },
@@ -40,7 +40,7 @@ module.exports = {
       {
         step: '/licence-holder-address',
         field: 'licence-holder-address-line-2',
-        parse: value => value || 'Not Provided'
+        parse: (value, req) => value || req.translate('journey.not-provided')
       },
       {
         step: '/licence-holder-address',

--- a/apps/registration/sections/summary-data-sections.js
+++ b/apps/registration/sections/summary-data-sections.js
@@ -1,4 +1,55 @@
 'use strict';
 
 module.exports = {
+    'licence-holder-details': {
+    steps: [
+      {
+        step: '/licence-holder-details',
+        field: 'company-name'
+      },
+      {
+        step: '/licence-holder-details',
+        field: 'name-of-responsible-person'
+      },
+      {
+        step: '/licence-holder-details',
+        field: 'company-number',
+        parse: value => value.toUpperCase() || 'Not Provided'
+      },
+      {
+        step: '/licence-holder-details',
+        field: 'telephone'
+      },
+      {
+        step: '/licence-holder-details',
+        field: 'email'
+      },
+      {
+        step: '/licence-holder-details',
+        field: 'website-url',
+        parse: value => value || 'Not Provided'
+      }
+    ]
+  },
+  'licence-holder-address': {
+    steps: [
+      {
+        step: '/licence-holder-address',
+        field: 'licence-holder-address-line-1'
+      },
+      {
+        step: '/licence-holder-address',
+        field: 'licence-holder-address-line-2',
+        parse: value => value || 'Not Provided'
+      },
+      {
+        step: '/licence-holder-address',
+        field: 'licence-holder-town-or-city'
+      },
+      {
+        step: '/licence-holder-address',
+        field: 'licence-holder-postcode'
+      }
+    ]
+  }
 };

--- a/apps/registration/translations/src/en/fields.json
+++ b/apps/registration/translations/src/en/fields.json
@@ -1,3 +1,34 @@
 {
-  
+  "company-name": {
+    "label": "Company name"
+  },
+  "name-of-responsible-person": {
+    "label": "Name of responsible person",
+    "hint": "The person who is in charge of the unit, department or area for which a licence is sought"
+  },
+  "company-number": {
+    "label": "Company number (optional)",
+    "hint": "Enter the number issued by Companies House"
+  },
+  "telephone": {
+    "label": "UK telephone number"
+  },
+  "email": {
+    "label": "Email address"
+  },
+  "website-url": {
+    "label": "Website URL (optional)"
+  },
+  "licence-holder-address-line-1": {
+    "label": "Address line 1"
+  },
+  "licence-holder-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "licence-holder-town-or-city": {
+    "label": "Town or city"
+  },
+  "licence-holder-postcode": {
+    "label": "Postcode"
+  }
 }

--- a/apps/registration/translations/src/en/journey.json
+++ b/apps/registration/translations/src/en/journey.json
@@ -3,5 +3,6 @@
   "serviceName": "Register for controlled substance licensing",
   "error": "Error",
   "warning": "Warning",
-  "uploading": "Uploading your file..."
+  "uploading": "Uploading your file...",
+  "not-provided": "Not provided"
 }

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -2,5 +2,14 @@
   "start": {
     "header": "Register for the controlled substance licensing system",
     "pageTitle": "Registration"
+  },
+
+  "licence-holder-details": {
+    "header": "Licence holder details"
+  },
+
+  "licence-holder-address": {
+    "header": "Licence holder address",
+    "intro": "This is the address your business is registered at."
   }
 }

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -11,5 +11,28 @@
   "licence-holder-address": {
     "header": "Licence holder address",
     "intro": "This is the address your business is registered at."
+  },
+
+  "confirm": {
+    "header": "Check your answers before submitting your registration",
+    "sections": {
+      "licence-holder-details": {
+        "header": "Licence holder details"
+      },
+      "licence-holder-address": {
+        "header": "Licence holder address"
+      }
+    },
+    "fields": {
+      "company-name": {
+        "label": "Licence holder name"
+      },
+      "telephone": {
+        "label": "Contact phone number"
+      },
+      "email": {
+        "label": "Contact email address"
+      }
+    }
   }
 }

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -1,3 +1,46 @@
 {
-  
+  "company-name": {
+    "required": "Enter a company name",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Company name must be between 2 and 200 characters",
+    "minlength": "Company name must be between 2 and 200 characters"
+  },
+  "name-of-responsible-person": {
+    "required": "Enter the name of the person who will be responsible for the licence",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Name of the responsible person must between 1 and 250 characters"
+  },
+  "company-number": {
+    "companyNumber": "Enter a real company number, like 16850062"
+  },
+  "telephone": {
+    "required": "Enter a UK telephone number",
+    "ukPhoneNumber": "Enter a UK telephone number in the correct format, like 01632 960001 or +44 808 157 0192"
+  },
+  "email": {
+    "required": "Enter an email address",
+    "email": "Enter a real email address"
+  },
+  "website-url": {
+    "url": "Enter a real website URL",
+    "maxlength": "Website URL must be between 1 and 250 characters"
+  },
+  "licence-holder-address-line-1": {
+    "required": "Enter a licence holder address",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 1 must be between 1 and 250 characters"
+  },
+  "licence-holder-address-line-2": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 2 must be between 1 and 250 characters"
+  },
+  "licence-holder-town-or-city": {
+    "required": "Enter a town or city",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Town or city must be between 1 and 250 characters"
+  },
+  "licence-holder-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a real UK postcode"
+  }
 }


### PR DESCRIPTION
## What? 
Adds licence details and licence address pages to registration journey
[CSL-129](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-129)
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


