### PR TITLE
CSL - THC - 168, 169 - Added pages for other regulatory licences and refused licences 

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -49,6 +49,33 @@ module.exports = {
       }
     ]
   },
+
+  'why-new-licence': {
+    mixin: 'radio-group',
+    options: [{ value: 'moving-site' }, { value: 'why-new-licence' }],
+    validate: ['required'],
+    className: ['govuk-radios'],
+    legend: {
+      className: 'visuallyhidden'
+    }
+  },
+  'is-contractual-agreement': {
+    mixin: 'radio-group',
+    options: [{ value: 'yes' }, { value: 'no' }],
+    validate: ['required'],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'visuallyhidden'
+    }
+  },
+  'moving-site-date': dateComponent('moving-site-date', {
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date',
+      { type: 'after', arguments: ['0', 'days'] }
+    ]
+  }),
   'company-name': {
     mixin: 'input-text',
     validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],
@@ -225,32 +252,6 @@ module.exports = {
     validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
     attributes: [{ attribute: 'rows', value: 8 }]
   },
-  'why-new-licence': {
-    mixin: 'radio-group',
-    options: [{ value: 'moving-site' }, { value: 'why-new-licence' }],
-    validate: ['required'],
-    className: ['govuk-radios'],
-    legend: {
-      className: 'visuallyhidden'
-    }
-  },
-  'is-contractual-agreement': {
-    mixin: 'radio-group',
-    options: [{ value: 'yes' }, { value: 'no' }],
-    validate: ['required'],
-    className: ['govuk-radios', 'govuk-radios--inline'],
-    legend: {
-      className: 'visuallyhidden'
-    }
-  },
-  'moving-site-date': dateComponent('moving-site-date', {
-    mixin: 'input-date',
-    validate: [
-      'required',
-      'date',
-      { type: 'after', arguments: ['0', 'days'] }
-    ]
-  }),
   'authorised-witness-full-name': {
     mixin: 'input-text',
     validate: [
@@ -324,5 +325,77 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
+  },
+  'hold-other-regulatory-licences': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'other-licence-type': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 200 }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'other-licence-number': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 25 },
+      'alphanum'
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'other-licence-date-of-issue': dateComponent('other-licence-date-of-issue', {
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date',
+      { type: 'before', arguments: ['0', 'days'] },
+      { type: 'after', arguments: ['10', 'years'] }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-4'
+    }
+  }),
+  'is-licence-refused': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'refusal-reason': {
+    mixin: 'textarea',
+    isPageHeading: true,
+    validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }]
   }
 };

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -422,7 +422,7 @@ module.exports = {
     validate: [
       'required',
       'notUrl',
-      { type: 'minlength', arguments: 3 },
+      { type: 'minlength', arguments: 2 },
       { type: 'maxlength', arguments: 200 }
     ],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
@@ -431,8 +431,8 @@ module.exports = {
     mixin: 'input-text',
     validate: [
       'required',
-      { type: 'minlength', arguments: 3 },
-      { type: 'maxlength', arguments: 25 },
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 50 },
       'alphanum'
     ],
     className: ['govuk-input', 'govuk-!-width-two-thirds']

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -52,24 +52,27 @@ module.exports = {
 
   'why-new-licence': {
     mixin: 'radio-group',
-    options: [{ value: 'moving-site' }, { value: 'why-new-licence' }],
+    isPageHeading: 'true',
+    options: [{ value: 'moving-site' }, { value: 'another-site' }],
     validate: ['required'],
     className: ['govuk-radios'],
     legend: {
-      className: 'visuallyhidden'
+      className: 'govuk-!-margin-bottom-6'
     }
   },
   'is-contractual-agreement': {
     mixin: 'radio-group',
+    isPageHeading: 'true',
     options: [{ value: 'yes' }, { value: 'no' }],
     validate: ['required'],
     className: ['govuk-radios', 'govuk-radios--inline'],
     legend: {
-      className: 'visuallyhidden'
+      className: 'govuk-!-margin-bottom-6'
     }
   },
   'moving-site-date': dateComponent('moving-site-date', {
     mixin: 'input-date',
+    isPageHeading: 'true',
     validate: [
       'required',
       'date',

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -85,7 +85,9 @@ const steps = {
     next: '/licence-holder-details'
   },
 
-  '/when-contract-start': {},
+  '/when-contract-start': {
+    next: '/licence-holder-details'
+  },
 
   /** First time licensee - About the applicants */
 

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -150,10 +150,60 @@ const steps = {
 
   '/authorised-witness-dbs-updates': {
     fields: ['authorised-witness-dbs-subscription'],
-    next: '/confirm'
+    next: '/legal-business-proceedings'
   },
 
   '/legal-business-proceedings': {
+    next: '/criminal-conviction'
+  },
+
+  '/criminal-conviction': {
+    next: '/other-regulatory-licences'
+  },
+
+  '/other-regulatory-licences': {
+    fields: ['hold-other-regulatory-licences'],
+    forks: [
+      {
+        target: '/other-licence-details',
+        condition: {
+          field: 'hold-other-regulatory-licences',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/licence-refused'
+  },
+
+  '/other-licence-details': {
+    fields: [
+      'other-licence-type',
+      'other-licence-number',
+      'other-licence-date-of-issue'
+    ],
+    next: '/licence-refused'
+  },
+
+  '/licence-refused': {
+    fields: ['is-licence-refused'],
+    forks: [
+      {
+        target: '/refusal-reason',
+        condition: {
+          field: 'is-licence-refused',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/company-type'
+  },
+
+  '/refusal-reason': {
+    fields: ['refusal-reason'],
+    next: '/company-type'
+  },
+
+  '/company-type': {
     next: '/confirm'
   },
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -11,7 +11,13 @@ module.exports = {
       {
         step: '/when-moving-site',
         field: 'moving-site-date',
-        parse: date => date && formatDate(new Date(date))
+        parse: (value, req) => {
+          if (req.sessionModel.get('licensee-type') === 'existing-licensee-applying-for-new-site' &&
+            value) {
+            return formatDate(value);
+          }
+          return null;
+        }
       },
       {
         step: '/company-number-changed',
@@ -143,11 +149,23 @@ module.exports = {
       },
       {
         step: '/why-new-licence',
-        field: 'why-new-licence'
+        field: 'why-new-licence',
+        parse: (value, req) => {
+          if (req.sessionModel.get('licensee-type') === 'existing-licensee-applying-for-new-site') {
+            return value;
+          }
+          return null;
+        }
       },
       {
         step: '/contractual-agreement',
-        field: 'is-contractual-agreement'
+        field: 'is-contractual-agreement',
+        parse: (value, req) => {
+          if (req.sessionModel.get('licensee-type') === 'existing-licensee-applying-for-new-site') {
+            return value;
+          }
+          return null;
+        }
       },
       {
         step: '/legal-business-proceedings',

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -127,8 +127,34 @@ module.exports = {
       {
         step: '/authorised-witness-dbs-updates',
         field: 'authorised-witness-dbs-subscription'
+      },
+      {
+        step: '/other-regulatory-licences',
+        field: 'hold-other-regulatory-licences'
+      },
+      {
+        step: '/other-licence-details',
+        field: 'other-licence-details',
+        parse: (list, req) => {
+          if(req.sessionModel.get('hold-other-regulatory-licences') === 'no') {
+            return null;
+          }
+          const otherLicenceDetails = [
+            req.sessionModel.get('other-licence-type'),
+            req.sessionModel.get('other-licence-number'),
+            formatDate(req.sessionModel.get('other-licence-date-of-issue'))
+          ];
+          return otherLicenceDetails.filter(element => element).join('\n');
+        }
+      },
+      {
+        step: '/licence-refused',
+        field: 'is-licence-refused'
+      },
+      {
+        step: '/refusal-reason',
+        field: 'refusal-reason'
       }
-
     ]
   }
 };

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -168,10 +168,8 @@ module.exports = {
       {
         step: '/other-licence-details',
         field: 'other-licence-details',
+        dependsOn: 'hold-other-regulatory-licences',
         parse: (list, req) => {
-          if(req.sessionModel.get('hold-other-regulatory-licences') === 'no') {
-            return null;
-          }
           const otherLicenceDetails = [
             req.sessionModel.get('other-licence-type'),
             req.sessionModel.get('other-licence-number'),

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -101,7 +101,7 @@
     "label": "DBS reference"
   },
   "responsible-person-dbs-date-of-issue": {
-    "label": "Date of issue or application"
+    "legend": "Date of issue or application"
   },
   "responsible-officer-dbs-subscription": {
     "legend": "Has the responsible person subscribed to DBS updates?",
@@ -131,19 +131,22 @@
     "hint": "Providing a detailed description will help us process your application faster"
   },
   "why-new-licence": {
+    "legend": "Why are you requesting a new licence?",
     "options": {
       "moving-site": {
         "label": "We are moving site"
       },
-      "why-new-licence": {
+      "another-site": {
         "label": "For another site"
       }
     }
   },
   "moving-site-date": {
+    "legend": "When are you moving site?",
     "hint": "Enter the date you plan to move sites"
   },
   "is-contractual-agreement": {
+    "legend": "Is the new site part of a contractual agreement?",
     "options": {
       "yes": {
         "label": "Yes"
@@ -173,7 +176,7 @@
     "label": "DBS reference"
   },
   "authorised-witness-dbs-date-of-issue": {
-    "label": "Date of issue or application"
+    "legend": "Date of issue or application"
   },
   "authorised-witness-dbs-subscription": {
     "legend": "Has the authorised witness subscribed to DBS updates?",
@@ -254,7 +257,7 @@
     "label": "Licence number"
   },
   "other-licence-date-of-issue": {
-    "label": "Date of issue or application"
+    "legend": "Date of issue or application"
   },
   "is-licence-refused": {
     "legend": "Has your organisation ever been refused a licence?",

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -175,6 +175,18 @@
   "authorised-witness-dbs-date-of-issue": {
     "label": "Date of issue or application"
   },
+  "hold-other-regulatory-licences": {
+    "legend": "Do you hold any Home Office or other regulatory licenses?",
+    "hint": "This includes animal scientific procedures and firearms",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "authorised-witness-dbs-subscription": {
     "legend": "Has the authorised witness subscribed to DBS updates?",
     "options": {
@@ -185,5 +197,30 @@
         "label": "No"
       }
     }
+  },
+  "other-licence-type": {
+    "label": "Licence type"
+  },
+  "other-licence-number": {
+    "label": "Licence number"
+  },
+  "other-licence-date-of-issue": {
+    "label": "Date of issue or application"
+  },
+  "is-licence-refused": {
+    "legend": "Has your organisation ever been refused a licence?",
+    "hint": "This means licences issued by central or local government bodies and authorities, including the police",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "refusal-reason": {
+    "label": "Details of why you were refused a licence",
+    "hint": "Enter details of what the licence was, the issuing body and the reason for the refusal"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -175,9 +175,8 @@
   "authorised-witness-dbs-date-of-issue": {
     "label": "Date of issue or application"
   },
-  "hold-other-regulatory-licences": {
-    "legend": "Do you hold any Home Office or other regulatory licenses?",
-    "hint": "This includes animal scientific procedures and firearms",
+  "authorised-witness-dbs-subscription": {
+    "legend": "Has the authorised witness subscribed to DBS updates?",
     "options": {
       "yes": {
         "label": "Yes"
@@ -187,8 +186,9 @@
       }
     }
   },
-  "authorised-witness-dbs-subscription": {
-    "legend": "Has the authorised witness subscribed to DBS updates?",
+  "hold-other-regulatory-licences": {
+    "legend": "Do you hold any Home Office or other regulatory licenses?",
+    "hint": "This includes animal scientific procedures and firearms",
     "options": {
       "yes": {
         "label": "Yes"

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -34,6 +34,9 @@
   "authorised-witness-dbs": {
     "header": "DBS information for authorised witness"
   },
+  "other-licence-details": {
+    "header": "Licence details"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {
@@ -83,6 +86,9 @@
       },
       "authorised-witness-dbs-subscription": {
         "label": "Authorised witness subscribed to DBS updates?"
+      },
+      "other-licence-details": {
+        "label": "Licence Details"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -18,15 +18,6 @@
   "site-responsible-officer-dbs": {
     "header": "DBS information for the responsible person"
   },
-  "why-new-licence": {
-    "header": "Why are you requesting a new licence?"
-  },
-  "when-moving-site": {
-    "header": "When are you moving site?"
-  },
-  "contractual-agreement": {
-    "header": "Is the new site part of a contractual agreement?"
-  },
   "authorised-witness-details": {
     "header": "Authorised witness details",
     "intro": "Enter the details of the person who is responsible for witnessing the destruction of the controlled parts of the plant."

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -189,7 +189,7 @@
     "required": "Enter the date of issue or application",
     "date": "Enter a real date of issue or application",
     "before": "Date of issue or application must be today's date or in the past",
-    "after": "Other licence cannot be more than 10 years old."
+    "after": "Date of issue or application must be in the past 50 years"
   },
   "is-licence-refused": {
     "required": "Select if your organisation has ever been refused a licence"

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -193,13 +193,13 @@
   "other-licence-type": {
     "required": "Enter the licence type, for example the name of the licence",
     "notUrl": "Your answer must not contain URLs or links",
-    "maxlength": "Licence type must be between 3 and 200 characters",
-    "minlength": "Licence type must be between 3 and 200 characters"
+    "maxlength": "Licence type must be between 2 and 200 characters",
+    "minlength": "Licence type must be between 2 and 200 characters"
   },
   "other-licence-number": {
     "required": "Enter the licence number or a reference number",
-    "maxlength": "Licence number must be between 3 and 25 characters",
-    "minlength": "Licence number must be between 3 and 25 characters",
+    "maxlength": "Licence number must be between 2 and 50 characters",
+    "minlength": "Licence number must be between 2 and 50 characters",
     "alphanum": "Enter a real licence number or application reference number"
   },
   "other-licence-date-of-issue": {

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -171,16 +171,16 @@
     "required": "Select if the authorised witness has subscribed to DBS updates"
   },
   "hold-other-regulatory-licences": {
-    "required": "Select if you hold any Home Office or other regulatory licenses"
+    "required": "Select if you hold any Home Office or other regulatory licences"
   },
   "other-licence-type": {
-    "required": "Enter the licence type",
+    "required": "Enter the licence type, for example the name of the licence",
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "Licence type must be between 3 and 200 characters",
     "minlength": "Licence type must be between 3 and 200 characters"
   },
   "other-licence-number": {
-    "required": "Enter a licence number",
+    "required": "Enter the licence number or a reference number",
     "maxlength": "Licence number must be between 3 and 25 characters",
     "minlength": "Licence number must be between 3 and 25 characters",
     "alphanum": "Enter a real licence number or application reference number"
@@ -188,11 +188,11 @@
   "other-licence-date-of-issue": {
     "required": "Enter the date of issue or application",
     "date": "Enter a real date of issue or application",
-    "before": "Other licence date of issue or application must not be in the future",
+    "before": "Date of issue or application must be today's date or in the past",
     "after": "Other licence cannot be more than 10 years old."
   },
   "is-licence-refused": {
-    "required": "Select if your organisation ever been refused a licence"
+    "required": "Select if your organisation has ever been refused a licence"
   },
   "refusal-reason": {
     "required": "Enter details of why you were refused a licence",

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -169,5 +169,34 @@
   },
   "authorised-witness-dbs-subscription": {
     "required": "Select if the authorised witness has subscribed to DBS updates"
+  },
+  "hold-other-regulatory-licences": {
+    "required": "Select if you hold any Home Office or other regulatory licenses"
+  },
+  "other-licence-type": {
+    "required": "Enter the licence type",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Licence type must be between 3 and 200 characters",
+    "minlength": "Licence type must be between 3 and 200 characters"
+  },
+  "other-licence-number": {
+    "required": "Enter a licence number",
+    "maxlength": "Licence number must be between 3 and 25 characters",
+    "minlength": "Licence number must be between 3 and 25 characters",
+    "alphanum": "Enter a real licence number or application reference number"
+  },
+  "other-licence-date-of-issue": {
+    "required": "Enter the date of issue or application",
+    "date": "Enter a real date of issue or application",
+    "before": "Other licence date of issue or application must not be in the future",
+    "after": "Other licence cannot be more than 10 years old."
+  },
+  "is-licence-refused": {
+    "required": "Select if your organisation ever been refused a licence"
+  },
+  "refusal-reason": {
+    "required": "Enter details of why you were refused a licence",
+    "maxlength": "Details of why you were refused a licence must be 2,000 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
   }
 }


### PR DESCRIPTION
## What? 

[CSL-168](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-168),  [CSL-169](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-169)-  Added pages for /other-regulatory-licences, /other-licence-details, /licence-refused and /refusal-reason

## How? 
- Added necessary step configuration and field specific variables. 
- Added required field validation for all pages

## Anything Else? (optional)

Validation error messages are updated. 

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


