### PR TITLE
[CSL 136 Registration] add business charity section pages

### DIFF
--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'company-name': {
     mixin: 'input-text',
@@ -50,5 +49,39 @@ module.exports = {
     validate: ['required', 'postcode'],
     formatter: ['ukPostcode'],
     className: ['govuk-input', 'govuk-input--width-10']
+  },
+  'registered-charity': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: ['required'],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'legal-identity-changed': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: ['required'],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   }
 };

--- a/apps/registration/index.js
+++ b/apps/registration/index.js
@@ -29,10 +29,33 @@ const steps = {
       'licence-holder-town-or-city',
       'licence-holder-postcode'
     ],
-    next: '/reuse-premises-address'
+    next: '/registered-charity'
   },
 
-  '/reuse-premises-address': {
+  '/registered-charity': {
+    fields: ['registered-charity'],
+    next: '/legal-identity-changed'
+  },
+
+  '/legal-identity-changed': {
+    fields: ['legal-identity-changed'],
+    forks: [
+      {
+        target: '/previously-held-licence',
+        condition: {
+          field: 'legal-identity-changed',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/business-type'
+  },
+
+  '/previously-held-licence': {
+    next: '/business-type'
+  },
+
+  '/business-type': {
     next: '/confirm'
   },
 

--- a/apps/registration/sections/summary-data-sections.js
+++ b/apps/registration/sections/summary-data-sections.js
@@ -51,5 +51,18 @@ module.exports = {
         field: 'licence-holder-postcode'
       }
     ]
+  },
+  'business-details': {
+    steps: [
+      {
+        step: '/registered-charity',
+        field: 'registered-charity'
+      },
+
+      {
+        step: '/legal-identity-changed',
+        field: 'legal-identity-changed'
+      }
+    ]
   }
 };

--- a/apps/registration/translations/src/en/fields.json
+++ b/apps/registration/translations/src/en/fields.json
@@ -30,5 +30,27 @@
   },
   "licence-holder-postcode": {
     "label": "Postcode"
+  },
+  "registered-charity": {
+    "legend": "Is the business a registered charity?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "legal-identity-changed": {
+    "legend": "Has your legal identity changed at Companies House in the last 3 years?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -21,6 +21,9 @@
       },
       "licence-holder-address": {
         "header": "Licence holder address"
+      },
+      "business-details": {
+        "header": "Business details"
       }
     },
     "fields": {

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -42,5 +42,11 @@
   "licence-holder-postcode": {
     "required": "Enter a postcode",
     "postcode": "Enter a real UK postcode"
+  },
+  "registered-charity": {
+    "required": "Select if the business is a registered charity"
+  },
+  "legal-identity-changed": {
+    "required": "Select if your legal identity has changed in the last 3 years"
   }
 }


### PR DESCRIPTION
## What? 
Added two pages "Is the business a registered charity" and "Has your legal identity changed at Companies House in the last 3 years?" pages. Please see ticket [CSL-136](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-136)
## Why? 
As per business requirements
## How? 
- Added two new fields for the two pages in the field/index.js file
- Added the routes for the two pages in the index.js file
- Updated the confirm page to include the two new fields
- Added the relevant text for the fields and validation json files
- Added a fork for correct redirection on the "Has your legal identity changed at Companies House in the last 3 years?" page. 
## Testing?
Manual developer test conducted
## Screenshots (optional)
![Screenshot 2025-03-31 at 12 26 58](https://github.com/user-attachments/assets/7158a147-ccb9-4c26-866b-1821872e1649)
![Screenshot 2025-03-31 at 12 27 42](https://github.com/user-attachments/assets/ca7db9b0-1e3e-4b43-b2e0-acf9a46f9ae8)
![Screenshot 2025-03-31 at 12 28 20](https://github.com/user-attachments/assets/b6ad8766-b874-4175-a27e-21e46951dab8)
## Anything 
Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


