### PR TITLE
CSL-168 - Updated the summary page field conditional check 

### DIFF
--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -198,8 +198,10 @@ module.exports = {
       {
         step: '/other-licence-details',
         field: 'other-licence-details',
-        dependsOn: 'hold-other-regulatory-licences',
         parse: (list, req) => {
+          if (req.sessionModel.get('hold-other-regulatory-licences') === 'no') {
+            return null;
+          }
           const otherLicenceDetails = [
             req.sessionModel.get('other-licence-type'),
             req.sessionModel.get('other-licence-number'),


### PR DESCRIPTION

## What? 

To fix the issue in UAT, added the conditional check in summary page field to hide when selecting the option 'no' in page /other-regulatory-licences

## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


