### PR TITLE
CSL - THC - 171, 172 - Added pages in THC flow

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -525,5 +525,48 @@ module.exports = {
     isPageHeading: true,
     validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
     attributes: [{ attribute: 'rows', value: 8 }]
+  },
+  'company-type': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'public-limited'
+      },
+      {
+        value: 'private'
+      },
+      {
+        value: 'other'
+      }
+    ],
+    className: ['govuk-radios'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'describe-business-model': {
+    mixin: 'textarea',
+    isPageHeading: true,
+    validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }]
+  },
+  'cultivate-industrial-hemp': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -327,7 +327,10 @@ const steps = {
       },
       {
         target: '/cultivate-industrial-hemp',
-        condition: req => req.sessionModel.get('licensee-type') === 'existing-licensee-renew-or-change-site'
+        condition: {
+          field: 'licensee-type',
+          value: 'existing-licensee-renew-or-change-site'
+        }
       }
     ],
     next: '/company-certificate'

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -316,8 +316,64 @@ const steps = {
   },
 
   '/company-type': {
+    fields: ['company-type'],
+    forks: [
+      {
+        target: '/business-model',
+        condition: {
+          field: 'company-type',
+          value: 'other'
+        }
+      },
+      {
+        target: '/cultivate-industrial-hemp',
+        condition: req => req.sessionModel.get('licensee-type') === 'existing-licensee-renew-or-change-site'
+      }
+    ],
+    next: '/company-certificate'
+  },
+
+  '/business-model': {
+    fields: ['describe-business-model'],
+    next: '/cultivate-industrial-hemp'
+  },
+
+  '/company-certificate': {
+    behaviours: [
+      SaveDocument('company-registration-certificate', 'file-upload'),
+      RemoveDocument('company-registration-certificate')
+    ],
+    fields: ['file-upload'],
+    locals: {
+      documentCategory: {
+        name: 'company-registration-certificate'
+      }
+    },
+    template: 'company-registration-certificate',
+    next: '/cultivate-industrial-hemp'
+  },
+
+  '/cultivate-industrial-hemp': {
+    fields: ['cultivate-industrial-hemp'],
+    forks: [
+      {
+        target: '/where-cultivating-cannabis',
+        condition: {
+          field: 'cultivate-industrial-hemp',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/no-licence-needed'
+  },
+
+  '/where-cultivating-cannabis': {
     next: '/confirm'
   },
+
+  '/no-licence-needed': {
+  },
+
 
   /** Continue an application */
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -252,6 +252,28 @@ module.exports = {
       {
         step: '/refusal-reason',
         field: 'refusal-reason'
+      },
+      {
+        step: '/company-type',
+        field: 'company-type'
+      },
+      {
+        step: '/business-model',
+        field: 'describe-business-model'
+      },
+      {
+        step: '/company-certificate',
+        field: 'company-registration-certificate',
+        parse: (documents, req) => {
+          if (req.sessionModel.get('licensee-type') === 'existing-licensee-renew-or-change-site') {
+            return null;
+          }
+          return Array.isArray(documents) && documents.length > 0 ? documents.map(doc => doc.name).join('\n') : null;
+        }
+      },
+      {
+        step: '/cultivate-industrial-hemp',
+        field: 'cultivate-industrial-hemp'
       }
     ]
   }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -312,5 +312,34 @@
   "refusal-reason": {
     "label": "Details of why you were refused a licence",
     "hint": "Enter details of what the licence was, the issuing body and the reason for the refusal"
+  },
+  "company-type": {
+    "legend": "What type of company is your organisation?",
+    "options": {
+      "public-limited": {
+        "label": "Public limited company"
+      },
+      "private": {
+        "label": "Private company"
+      },
+      "other": {
+        "label": "Other"
+      }
+    }
+  },
+  "describe-business-model": {
+    "label": "Describe your business model",
+    "hint": "If applicable, include your company type as registered with Companies House"
+  },
+  "cultivate-industrial-hemp": {
+    "legend": "Is the licence needed to cultivate and possess low THC cannabis (industrial hemp)?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -40,6 +40,9 @@
     "header": "Upload company registration certificate",
     "intro": "Upload a scanned copy of your company registration certificate."
   },
+  "no-licence-needed": {
+    "header": "You need to apply for a controlled drugs licence"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -36,6 +36,10 @@
   "other-licence-details": {
     "header": "Licence details"
   },
+  "company-certificate": {
+    "header": "Upload company registration certificate",
+    "intro": "Upload a scanned copy of your company registration certificate."
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {
@@ -124,6 +128,12 @@
       },
       "other-licence-details": {
         "label": "Licence Details"
+      },
+      "describe-business-model": {
+        "label": "Your business model"
+      },
+      "cultivate-industrial-hemp": {
+        "label": "Is the licence needed to cultivate low THC cannabis?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -233,5 +233,16 @@
     "required": "Enter details of why you were refused a licence",
     "maxlength": "Details of why you were refused a licence must be 2,000 characters or less",
     "notUrl": "Your answer must not contain URLs or links"
+  },
+  "company-type": {
+    "required": "Select your organisation's company type"
+  },
+  "describe-business-model": {
+    "required": "Enter a description of your business model",
+    "maxlength": "Description of your business model must be 2,000 character or less",
+    "notUrl": "Your answer must not contain URLs or links"
+  },
+  "cultivate-industrial-hemp": {
+    "required": "Select if the licence is needed to cultivate and possess low THC cannabis"
   }
 }

--- a/apps/industrial-hemp/views/content/en/apply-for-controlled-drugs-licence.md
+++ b/apps/industrial-hemp/views/content/en/apply-for-controlled-drugs-licence.md
@@ -1,3 +1,1 @@
-# You need to apply for a controlled drugs licence
-
 If you are cultivating or possessing something different from low THC cannabis, you need to [apply for a controlled drugs licence](/licence-type).

--- a/apps/industrial-hemp/views/content/en/apply-for-controlled-drugs-licence.md
+++ b/apps/industrial-hemp/views/content/en/apply-for-controlled-drugs-licence.md
@@ -1,0 +1,3 @@
+# You need to apply for a controlled drugs licence
+
+If you are cultivating or possessing something different from low THC cannabis, you need to [apply for a controlled drugs licence](/licence-type).

--- a/apps/industrial-hemp/views/no-licence-needed.html
+++ b/apps/industrial-hemp/views/no-licence-needed.html
@@ -1,0 +1,5 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}apply-for-controlled-drugs-licence{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -1,12 +1,12 @@
 module.exports = {
   'company-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'name-of-responsible-person': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'company-number': {

--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   'company-name': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'minlength', arguments: 3 }, { type: 'maxlength', arguments: 200 }],
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 2 }, { type: 'maxlength', arguments: 200 }],
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'name-of-responsible-person': {

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -8,7 +8,8 @@
   "name-of-responsible-person": {
     "required": "Enter the name of the person who will be responsible for the licence",
     "notUrl": "Your answer must not contain URLs or links",
-    "maxlength": "Name of the responsible person must between 1 and 250 characters"
+    "maxlength": "Name of the responsible person must between 3 and 200 characters",
+    "minlength": "Name of the responsible person must between 3 and 200 characters"
   },
   "company-number": {
     "companyNumber": "Enter a real company number, like 16850062"

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -3,6 +3,10 @@
 
 @import "hof/frontend/themes/gov-uk/styles/govuk";
 
+h1 {
+  @extend .govuk-heading-l;
+}
+
 h2 {
   @extend .govuk-heading-m;
   margin-top: 20px;

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -3,10 +3,6 @@
 
 @import "hof/frontend/themes/gov-uk/styles/govuk";
 
-h1 {
-  @extend .govuk-heading-l;
-}
-
 h2 {
   @extend .govuk-heading-m;
   margin-top: 20px;


### PR DESCRIPTION
## What? 

[CSL-171](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-171) , [CSL-172](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-172), [CSL-199](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-199)-  Added pages for /company-type, /company-certificate, /business-model, /cultivate-industrial-hemp in THC form flow

## How? 
- Added necessary step configuration and field specific variables. 
- Added required field validation for all pages

## Anything Else? (optional)
updated the validation minlength and maxlength for name of reponsible person field in /licence-holder-details page in registration flow

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


