### PR TITLE
[CSL-140-Reg] add two new pages for previous for legally registered i…

### DIFF
--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -1,3 +1,5 @@
+const dateComponent = require('hof').components.date;
+
 module.exports = {
   'company-name': {
     mixin: 'input-text',
@@ -83,5 +85,56 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
-  }
+  },
+  'previously-held-licence': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: ['required'],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+
+  },
+  'previous-licence-number': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 3 },
+      { type: 'maxlength', arguments: 50 },
+      'alphanum'
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'previous-licence-holder-name': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'previous-licence-date-of-issue': dateComponent('previous-licence-date-of-issue', {
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date',
+      {type: 'after', arguments: ['1924-12-31'] },
+      {type: 'before', arguments: ['0', 'days'] }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-4'
+    }
+  })
 };

--- a/apps/registration/index.js
+++ b/apps/registration/index.js
@@ -52,6 +52,25 @@ const steps = {
   },
 
   '/previously-held-licence': {
+    fields: ['previously-held-licence'],
+    forks: [
+      {
+        target: '/previous-licence-details',
+        condition: {
+          field: 'previously-held-licence',
+          value: 'yes'
+        }
+      }
+    ],
+    next: '/business-type'
+  },
+
+  '/previous-licence-details': {
+    fields: [
+      'previous-licence-number',
+      'previous-licence-holder-name',
+      'previous-licence-date-of-issue'
+    ],
     next: '/business-type'
   },
 

--- a/apps/registration/sections/summary-data-sections.js
+++ b/apps/registration/sections/summary-data-sections.js
@@ -1,4 +1,5 @@
 'use strict';
+const { formatDate } = require('../../../utils');
 
 module.exports = {
   'licence-holder-details': {
@@ -62,6 +63,30 @@ module.exports = {
       {
         step: '/legal-identity-changed',
         field: 'legal-identity-changed'
+      },
+
+      {
+        step: '/previously-held-licence',
+        field: 'previously-held-licence'
+      },
+
+      {
+        dependsOn: 'previously-held-licence',
+        step: '/previous-licence-details',
+        field: 'previous-licence-number'
+      },
+
+      {
+        dependsOn: 'previously-held-licence',
+        step: '/previous-licence-details',
+        field: 'previous-licence-holder-name'
+      },
+
+      {
+        dependsOn: 'previously-held-licence',
+        step: '/previous-licence-details',
+        field: 'previous-licence-date-of-issue',
+        parse: value => value ? formatDate(value) : null
       }
     ]
   }

--- a/apps/registration/translations/src/en/fields.json
+++ b/apps/registration/translations/src/en/fields.json
@@ -52,5 +52,27 @@
         "label": "No"
       }
     }
+  },
+  "previously-held-licence": {
+    "legend": "Under your previous legally registered identity, did you hold a controlled drugs licence?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "previous-licence-number": {
+    "label": "Previous licence number"
+  },
+  "previous-licence-holder-name": {
+    "label": "Licence holder name",
+    "hint": "The name of the company that held the previous licence"
+  },
+  "previous-licence-date-of-issue": {
+    "legend": "Date issued",
+    "hint": "For example, 21 3 2019"
   }
 }

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -12,6 +12,9 @@
     "header": "Licence holder address",
     "intro": "This is the address your business is registered at."
   },
+  "previous-licence-details": {
+    "header": "Previous licence details"
+  },
 
   "confirm": {
     "header": "Check your answers before submitting your registration",
@@ -35,6 +38,15 @@
       },
       "email": {
         "label": "Contact email address"
+      },
+      "previously-held-licence": {
+        "label": "Did you previously hold a controlled drugs licence?"
+      },
+      "previous-licence-holder-name": {
+        "label": "Previous licence holder name"
+      },
+      "previous-licence-date-of-issue": {
+        "label": "Previous licence date issued"
       }
     }
   }

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -49,5 +49,27 @@
   },
   "legal-identity-changed": {
     "required": "Select if your legal identity has changed in the last 3 years"
+  },
+  "previously-held-licence": {
+    "required": "Select if you held a controlled drugs licence under your previous legal identity"
+  },
+  "previous-licence-number": {
+    "required": "Enter your previous licence number",
+    "notUrl": "Your answer must not contain URLs or links",
+    "minlength": "Previous licence number must be between 3 and 50 characters",
+    "maxlength": "Previous licence number must be between 3 and 50 characters",
+    "alphanum": "Enter your previous licence number"
+  },
+  "previous-licence-holder-name": {
+    "required": "Enter the name of the company that held the previous licence",
+    "notUrl": "Your answer must not contain URLs or links",
+    "minlength": "Previous licence holder name must be between 2 and 250 characters",
+    "maxlength": "Previous licence holder name must be between 2 and 250 characters"
+  },
+  "previous-licence-date-of-issue": {
+    "required": "Enter the date the previous licence was issued",
+    "date": "Enter a real date",
+    "before": "Date the previous licence was issued must be in the past",
+    "after": "Date when the previous licence was issued must be within the last 100 years"
   }
 }


### PR DESCRIPTION
## What? 
Added two new pages '/previously-held-license' and '/previous-license-details'. Please see ticket [CSL-140](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-140)
## Why? 
As per Business requirements
## How? 
- Added the routes for the two new pages in the index.js file
- Added the fields for the new pages in the fields index.js file
- Added the text in the fields and pages (json) files
- Update the /confirm page to include the new fields.
## Testing?
Manual developer test conducted
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


