### PR TITLE
CSL - 173 - THC - Added /where-cultivating-cannabis page in low THC flow

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -586,5 +586,22 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
+  },
+  'where-cultivating-cannabis': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'inside'
+      },
+      {
+        value: 'outside'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -375,10 +375,27 @@ const steps = {
   },
 
   '/where-cultivating-cannabis': {
-    next: '/confirm'
+    fields: ['where-cultivating-cannabis'],
+    forks: [
+      {
+        target: '/field-acreage',
+        condition: {
+          field: 'where-cultivating-cannabis',
+          value: 'outside'
+        }
+      }
+    ],
+    next: '/controlled-drugs-licence'
   },
 
   '/no-licence-needed': {
+  },
+
+  '/controlled-drugs-licence': {
+  },
+
+  '/field-acreage': {
+    next: '/confirm'
   },
 
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -295,6 +295,10 @@ module.exports = {
       {
         step: '/cultivate-industrial-hemp',
         field: 'cultivate-industrial-hemp'
+      },
+      {
+        step: '/where-cultivating-cannabis',
+        field: 'where-cultivating-cannabis'
       }
     ]
   }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -348,5 +348,16 @@
         "label": "No"
       }
     }
+  },
+  "where-cultivating-cannabis": {
+    "legend": "Where will you be cultivating the low THC cannabis?",
+    "options": {
+      "inside": {
+        "label": "Inside"
+      },
+      "outside": {
+        "label": "Outside"
+      }
+    }
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -43,6 +43,12 @@
   "no-licence-needed": {
     "header": "You need to apply for a controlled drugs licence"
   },
+  "controlled-drugs-licence": {
+    "header": "You need to apply for a controlled drugs licence"
+  },
+  "field-acreage": {
+    "header": "What is the total acreage of the fields?"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -254,5 +254,8 @@
   },
   "cultivate-industrial-hemp": {
     "required": "Select if the licence is needed to cultivate and possess low THC cannabis"
+  },
+  "where-cultivating-cannabis": {
+    "required": "Select where you will be cultivating the low THC cannabis"
   }
 }

--- a/apps/industrial-hemp/views/content/en/apply-for-cd-licence-cultivating-THC-inside.md
+++ b/apps/industrial-hemp/views/content/en/apply-for-cd-licence-cultivating-THC-inside.md
@@ -1,0 +1,1 @@
+If you are cultivating low THC cannabis inside, you need to [apply for a controlled drugs licence](/licence-type).

--- a/apps/industrial-hemp/views/controlled-drugs-licence.html
+++ b/apps/industrial-hemp/views/controlled-drugs-licence.html
@@ -1,0 +1,5 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}apply-for-cd-licence-cultivating-THC-inside{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 

[CSL-173](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-173) -  Added pages for /where-cultivating-cannabis, /controlled-drugs-licence in THC form flow

## How? 
- Added necessary step configuration and field specific variables. 
- Added required field validation for all pages

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


