### PR TITLE
CSL-233, 234 - contract start date validation 

### DIFF
--- a/apps/controlled-drugs/fields/index.js
+++ b/apps/controlled-drugs/fields/index.js
@@ -1343,7 +1343,8 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'after', arguments: ['0', 'days'] }
+      { type: 'before', arguments: ['-1', 'years'] },
+      { type: 'after', arguments: ['1', 'years'] }
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/controlled-drugs/fields/index.js
+++ b/apps/controlled-drugs/fields/index.js
@@ -1343,8 +1343,8 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'before', arguments: ['-1', 'years'] },
-      { type: 'after', arguments: ['1', 'years'] }
+      { type: 'before', arguments: ['-1', 'years'] }, // Validate the date to be within 1 year in the future
+      { type: 'after', arguments: ['1', 'years'] } // Validate the date to be less than 1 year in the past
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/controlled-drugs/translations/src/en/validation.json
+++ b/apps/controlled-drugs/translations/src/en/validation.json
@@ -519,7 +519,8 @@
   "contract-start-date": {
     "required": "Enter a date",
     "date": "Enter a date in the correct format",
-    "after": "Contract start date must be in the future"
+    "after": "Contract start date must be in within the past year",
+    "before": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {
     "required": "Enter details about the contract and how it affects your licence application",

--- a/apps/controlled-drugs/translations/src/en/validation.json
+++ b/apps/controlled-drugs/translations/src/en/validation.json
@@ -519,7 +519,7 @@
   "contract-start-date": {
     "required": "Enter a date",
     "date": "Enter a date in the correct format",
-    "after": "Contract start date must be in within the past year",
+    "after": "Contract start date must be within the past year",
     "before": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -532,7 +532,7 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'before', arguments: ['0', 'years'] },
+      { type: 'before', arguments: ['-1', 'years'] },
       { type: 'after', arguments: ['1', 'years'] }
     ],
     legend: {

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -532,8 +532,8 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'before', arguments: ['-1', 'years'] },
-      { type: 'after', arguments: ['1', 'years'] }
+      { type: 'before', arguments: ['-1', 'years'] }, // Validate the date to be within 1 year in the future
+      { type: 'after', arguments: ['1', 'years'] } // Validate the date to be less than 1 year in the past
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -149,6 +149,9 @@
       },
       "cultivate-industrial-hemp": {
         "label": "Is the licence needed to cultivate low THC cannabis?"
+      },
+      "where-cultivating-cannabis": {
+        "label": "Where you will be cultivating the Low THC Cannabis?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -151,7 +151,7 @@
         "label": "Is the licence needed to cultivate low THC cannabis?"
       },
       "where-cultivating-cannabis": {
-        "label": "Where you will be cultivating the Low THC Cannabis?"
+        "label": "Where you will be cultivating Low THC Cannabis?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -237,8 +237,8 @@
   "contract-start-date": {
     "required": "Enter the contract start date",
     "date": "Enter a real contract start date",
-    "before": "Contract start date must be in the past",
-    "after": "Contract start date must be in within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
+    "before": "Contract start date must be in within the past year",
+    "after": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {
     "required": "Enter details about the contract and how it affects your licence application",

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -237,7 +237,7 @@
   "contract-start-date": {
     "required": "Enter the contract start date",
     "date": "Enter a real contract start date",
-    "before": "Contract start date must be in within the past year",
+    "before": "Contract start date must be within the past year",
     "after": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -174,7 +174,8 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'after', arguments: ['0', 'days'] }
+      { type: 'before', arguments: ['-1', 'years'] },
+      { type: 'after', arguments: ['1', 'years'] }
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/precursor-chemicals/fields/index.js
+++ b/apps/precursor-chemicals/fields/index.js
@@ -174,8 +174,8 @@ module.exports = {
     validate: [
       'required',
       'date',
-      { type: 'before', arguments: ['-1', 'years'] },
-      { type: 'after', arguments: ['1', 'years'] }
+      { type: 'before', arguments: ['-1', 'years'] }, // Validate the date to be within 1 year in the future
+      { type: 'after', arguments: ['1', 'years'] } // Validate the date to be less than 1 year in the past
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -40,7 +40,7 @@
   "contract-start-date": {
     "required": "Enter a date",
     "date": "Enter a date in the correct format",
-    "after": "Contract start date must be in within the past year",
+    "after": "Contract start date must be within the past year",
     "before": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {

--- a/apps/precursor-chemicals/translations/src/en/validation.json
+++ b/apps/precursor-chemicals/translations/src/en/validation.json
@@ -40,7 +40,8 @@
   "contract-start-date": {
     "required": "Enter a date",
     "date": "Enter a date in the correct format",
-    "after": "Contract start date must be in the future"
+    "after": "Contract start date must be in within the past year",
+    "before": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {
     "required": "Enter more detail about the contract and how it affects your application",


### PR DESCRIPTION
## What? 
[CSL-233](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-233), [CSL-234](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-234) - validation amendment in contract start date field

## Why? 
Date validation on this page needs to be made consistent with Low THC form [CSL-144](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-144)

## How? 
## Testing?
## Screenshots (optional)

## Anything Else? (optional)
Added summary label for where-cultivating-cannabis field in pages.json. changes related to ticket  - [CSL-173](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-173)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


