### PR TITLE
CSL - 144 - THC - updated the validation error message

### DIFF
--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -237,8 +237,8 @@
   "contract-start-date": {
     "required": "Enter the contract start date",
     "date": "Enter a real contract start date",
-    "before": "Contract start date must be within the past year",
-    "after": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
+    "after": "Contract start date must be within the past year",
+    "before": "Contract start date must be within the next year. Come back and re-apply later if you are applying for a new site more than 1 year in the future"
   },
   "contract-details": {
     "required": "Enter details about the contract and how it affects your licence application",


### PR DESCRIPTION
## What? 
swapped the validation error message between before and after in Low THC cannabis flow.
Bug fix in [CSL-144](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-144)

## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


