### PR TITLE
CSL-131: PATCH existing saved application in DB rather than duplicating

### DIFF
--- a/apps/common/behaviours/resume-form-session.js
+++ b/apps/common/behaviours/resume-form-session.js
@@ -74,8 +74,8 @@ module.exports = superclass => class extends superclass {
         req.sessionModel.set('start-new-application', true);
         req.sessionModel.set('application-id', applicationToResume.id);
       }
+      req.sessionModel.unset('application-to-resume');
     }
-    req.sessionModel.unset('application-to-resume');
     return super.saveValues(req, res, next);
   }
 

--- a/apps/common/behaviours/resume-form-session.js
+++ b/apps/common/behaviours/resume-form-session.js
@@ -71,7 +71,7 @@ module.exports = superclass => class extends superclass {
           return next(error);
         }
       } else {
-        req.sessionModel.set('start-new-application', true);
+        req.sessionModel.set('overwrite-application', true);
         req.sessionModel.set('application-id', applicationToResume.id);
       }
       req.sessionModel.unset('application-to-resume');

--- a/apps/common/behaviours/resume-form-session.js
+++ b/apps/common/behaviours/resume-form-session.js
@@ -60,14 +60,19 @@ module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     const resumeApplication = req.form.values['application-form-type'] === 'continue-an-application';
     const applicationToResume = req.sessionModel.get('application-to-resume');
-    if (resumeApplication && applicationToResume) {
-      try {
-        this.resumeSession(req, applicationToResume);
-      } catch (error) {
-        // eslint-disable-next-line max-len
-        const errorMessage = `Failed to restore application, saved session data is corrupt or cannot be resumed in this format. Reason: ${error}`;
-        req.log('error', errorMessage);
-        return next(error);
+    if (applicationToResume) {
+      if (resumeApplication) {
+        try {
+          this.resumeSession(req, applicationToResume);
+        } catch (error) {
+          // eslint-disable-next-line max-len
+          const errorMessage = `Failed to restore application, saved session data is corrupt or cannot be resumed in this format. Reason: ${error}`;
+          req.log('error', errorMessage);
+          return next(error);
+        }
+      } else {
+        req.sessionModel.set('start-new-application', true);
+        req.sessionModel.set('application-id', applicationToResume.id);
       }
     }
     req.sessionModel.unset('application-to-resume');

--- a/apps/common/behaviours/save-form-session.js
+++ b/apps/common/behaviours/save-form-session.js
@@ -34,11 +34,20 @@ module.exports = superclass => class extends superclass {
 
     req.log('info', `Saving Form Session: ${applicationId ?? 'New application'}`);
 
+    const patchData = { session };
+    if (applicationId && req.sessionModel.get('start-new-application')) {
+      req.log('info', `Overwriting saved application: ${applicationId}`);
+      patchData.created_at = new Date().toISOString();
+      req.sessionModel.unset('start-new-application');
+    }
+
+    const postData = { session, applicant_id, licence_type, status_id };
+
     try {
       const reqParams = {
         url: applicationId ? `${applicationsUrl}/${applicationId}` : applicationsUrl,
         method: applicationId ? 'PATCH' : 'POST',
-        data: applicationId ? { session } : { session, applicant_id, licence_type, status_id }
+        data: applicationId ? patchData : postData
       };
 
       const hofModel = new Model();
@@ -47,6 +56,10 @@ module.exports = superclass => class extends superclass {
       if (!response.data[0]?.id) {
         const errorMessage = `Id not received in response ${JSON.stringify(response.data)}`;
         throw new Error(errorMessage);
+      }
+
+      if (!applicationId) {
+        req.sessionModel.set('application-id', response.data[0].id);
       }
 
       // @todo CSL-133 Add save-and-exit

--- a/apps/common/behaviours/save-form-session.js
+++ b/apps/common/behaviours/save-form-session.js
@@ -35,10 +35,10 @@ module.exports = superclass => class extends superclass {
     req.log('info', `Saving Form Session: ${applicationId ?? 'New application'}`);
 
     const patchData = { session };
-    if (applicationId && req.sessionModel.get('start-new-application')) {
+    if (applicationId && req.sessionModel.get('overwrite-application')) {
       req.log('info', `Overwriting saved application: ${applicationId}`);
       patchData.created_at = new Date().toISOString();
-      req.sessionModel.unset('start-new-application');
+      req.sessionModel.unset('overwrite-application');
     }
 
     const postData = { session, applicant_id, licence_type, status_id };

--- a/test/unit/common/resume-form-session.test.js
+++ b/test/unit/common/resume-form-session.test.js
@@ -206,7 +206,7 @@ describe('resume-form-session', () => {
       req.form.values = { 'application-form-type': 'new-application' };
       const spiedResumeSession = jest.spyOn(instance, 'resumeSession');
       instance.saveValues(req, res, next);
-      expect(req.sessionModel.set).toHaveBeenCalledWith('start-new-application', true);
+      expect(req.sessionModel.set).toHaveBeenCalledWith('overwrite-application', true);
       expect(req.sessionModel.set).toHaveBeenCalledWith('application-id', 1);
       expect(req.sessionModel.set).not.toHaveBeenCalledWith(
         Object.assign({}, mockApplication.session, mockSavedApplicationProps)

--- a/test/unit/common/resume-form-session.test.js
+++ b/test/unit/common/resume-form-session.test.js
@@ -200,5 +200,19 @@ describe('resume-form-session', () => {
       instance.saveValues(req, res, next);
       expect(spiedResumeSession).not.toHaveBeenCalled();
     });
+
+    test('If the user is not resuming a session, only set the application-id and new application flag', () => {
+      const mockSavedApplicationProps = { 'application-id': 1 };
+      req.form.values = { 'application-form-type': 'new-application' };
+      const spiedResumeSession = jest.spyOn(instance, 'resumeSession');
+      instance.saveValues(req, res, next);
+      expect(req.sessionModel.set).toHaveBeenCalledWith('start-new-application', true);
+      expect(req.sessionModel.set).toHaveBeenCalledWith('application-id', 1);
+      expect(req.sessionModel.set).not.toHaveBeenCalledWith(
+        Object.assign({}, mockApplication.session, mockSavedApplicationProps)
+      );
+      expect(req.sessionModel.unset).toHaveBeenCalledWith('application-to-resume');
+      expect(spiedResumeSession).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/unit/common/save-form-session.test.js
+++ b/test/unit/common/save-form-session.test.js
@@ -116,6 +116,7 @@ describe('save-form-session', () => {
         }
       });
       expect(mockSessionAttributes.steps).toContain('/save-me');
+      expect(req.sessionModel.set).toHaveBeenCalledWith('application-id', 1);
     });
 
     test('calls HOFs _request method with the expected values when an application-id exists', async () => {
@@ -126,6 +127,19 @@ describe('save-form-session', () => {
         method: 'PATCH',
         data: { session: mockSessionAttributes }
       });
+    });
+
+    test('calls _request with expected values if application-id and start-new-application flag is set', async () => {
+      jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2025-02-23T00:00:00.000Z');
+      mockSessionAttributes['application-id'] = 1;
+      mockSessionAttributes['start-new-application'] = true;
+      await instance.successHandler(req, res, next);
+      expect(mockRequest).toHaveBeenCalledWith({
+        url: 'http://127.0.0.1:5000/applications/1',
+        method: 'PATCH',
+        data: { session: mockSessionAttributes, created_at: '2025-02-23T00:00:00.000Z' }
+      });
+      expect(req.sessionModel.unset).toHaveBeenCalledWith('start-new-application');
     });
 
     test('does not cause saving behaviour if the current path is in the exemption list', async () => {

--- a/test/unit/common/save-form-session.test.js
+++ b/test/unit/common/save-form-session.test.js
@@ -129,17 +129,17 @@ describe('save-form-session', () => {
       });
     });
 
-    test('calls _request with expected values if application-id and start-new-application flag is set', async () => {
+    test('calls _request with expected values if application-id and overwrite-application flag is set', async () => {
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2025-02-23T00:00:00.000Z');
       mockSessionAttributes['application-id'] = 1;
-      mockSessionAttributes['start-new-application'] = true;
+      mockSessionAttributes['overwrite-application'] = true;
       await instance.successHandler(req, res, next);
       expect(mockRequest).toHaveBeenCalledWith({
         url: 'http://127.0.0.1:5000/applications/1',
         method: 'PATCH',
         data: { session: mockSessionAttributes, created_at: '2025-02-23T00:00:00.000Z' }
       });
-      expect(req.sessionModel.unset).toHaveBeenCalledWith('start-new-application');
+      expect(req.sessionModel.unset).toHaveBeenCalledWith('overwrite-application');
     });
 
     test('does not cause saving behaviour if the current path is in the exemption list', async () => {

--- a/utils/index.js
+++ b/utils/index.js
@@ -43,13 +43,15 @@ const translateOption = (req, field, value) => {
  * formatDate('2023-10-23'); // returns '23 October 2023'
  */
 const formatDate = date => {
-  try {
-    const dateObj = new Date(date);
-    return new Intl.DateTimeFormat(config.dateLocales, config.dateFormat).format(dateObj);
-  } catch (error) {
-    logger.warn('Warning: Failed to format date', error);
-    return undefined;
+  if (date) {
+    try {
+      const dateObj = new Date(date);
+      return new Intl.DateTimeFormat(config.dateLocales, config.dateFormat).format(dateObj);
+    } catch (error) {
+      logger.warn('Warning: Failed to format date', error);
+    }
   }
+  return undefined;
 };
 
 /**


### PR DESCRIPTION
## What? 

Relates to [CSL-131](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-131) (Saving form sessions)

Updates the logic for saving applications so that if the user wants to make a new application when they have one (per form type - PC/CD/THC) saved already it will overwrite the `session` and `created_at` values in the old row, rather than creating a new one each time.

Updated tests related to the updated behaviours

Updated utils.formatDate so that it will return `undefined` as a default in the case of error or no `date` argument, but will log a warning if there was an error. This is because otherwise it is very noisy when trying to load values in '/information-you-have-given-us'.

## Why?

1. It is possible to create unlimited saved applications per form type per user, causing large request times to call back hundreds of DB rows to process in finding the latest one, where actually only one is required for storage at a time.
2. After a user has submitted an application it will be locked for resumption, but a user could go back and find their penultimate session if it still existed in the db, which could be confusing. Having only one saved form per application means the user will have to start a new one after their single saved application row has been locked by submission.


## How? 
## Testing?

Existing unit tests updated to cater for new conditions.

## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


