### PR TITLE
CSL-188 - THC - Added invoicing address and contact details and licence email address pages

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -766,7 +766,7 @@ module.exports = {
   'refund-accound-details': {
     mixin: 'textarea',
     validate: [ 'required', { type: 'maxlength', arguments: 500 }, 'notUrl' ],
-    attributes: [{ attribute: 'rows', value: 5 }]
+    attributes: [{ attribute: 'rows', value: 8 }]
   },
   'licence-email-address': {
     mixin: 'input-text',

--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -713,5 +713,65 @@ module.exports = {
     isPageHeading: true,
     validate: [ 'required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
     attributes: [{ attribute: 'rows', value: 8 }]
+  },
+  'invoicing-address-line-1': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-address-line-2': {
+    mixin: 'input-text',
+    validate: ['notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-address-town-or-city': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-address-postcode': {
+    mixin: 'input-text',
+    validate: ['required', 'postcode'],
+    formatter: ['ukPostcode'],
+    className: ['govuk-input', 'govuk-input--width-10']
+  },
+  'invoicing-contact-name': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: [3] },
+      { type: 'maxlength', arguments: [200] }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-contact-email': {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-contact-telephone': {
+    mixin: 'input-text',
+    validate: ['required'], // additional validation covered in custom-validation.js
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'invoicing-purchase-order-number': {
+    mixin: 'input-text',
+    validate: [
+      'notUrl',
+      { type: 'maxlength', arguments: [250] }
+    ],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'refund-accound-details': {
+    mixin: 'textarea',
+    validate: [ 'required', { type: 'maxlength', arguments: 500 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 5 }]
+  },
+  'licence-email-address': {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    isPageHeading: true,
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -522,8 +522,35 @@ const steps = {
   },
 
   '/invoicing-address': {
-    next: '/confirm'
-  },
+      fields: [
+        'invoicing-address-line-1',
+        'invoicing-address-line-2',
+        'invoicing-address-town-or-city',
+        'invoicing-address-postcode'
+      ],
+      next: '/invoicing-contact-details'
+    },
+  
+    '/invoicing-contact-details': {
+      behaviours: [customValidation],
+      fields: [
+        'invoicing-contact-name',
+        'invoicing-contact-email',
+        'invoicing-contact-telephone',
+        'invoicing-purchase-order-number',
+        'refund-accound-details'
+      ],
+      next: '/licence-email-address'
+    },
+  
+    '/licence-email-address': {
+      fields: ['licence-email-address'],
+      next: '/who-completing-application'
+    },
+
+    '/who-completing-application': {
+      next: '/confirm'
+    },
 
   /** Continue an application */
 

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -522,35 +522,35 @@ const steps = {
   },
 
   '/invoicing-address': {
-      fields: [
-        'invoicing-address-line-1',
-        'invoicing-address-line-2',
-        'invoicing-address-town-or-city',
-        'invoicing-address-postcode'
-      ],
-      next: '/invoicing-contact-details'
-    },
-  
-    '/invoicing-contact-details': {
-      behaviours: [customValidation],
-      fields: [
-        'invoicing-contact-name',
-        'invoicing-contact-email',
-        'invoicing-contact-telephone',
-        'invoicing-purchase-order-number',
-        'refund-accound-details'
-      ],
-      next: '/licence-email-address'
-    },
-  
-    '/licence-email-address': {
-      fields: ['licence-email-address'],
-      next: '/who-completing-application'
-    },
+    fields: [
+      'invoicing-address-line-1',
+      'invoicing-address-line-2',
+      'invoicing-address-town-or-city',
+      'invoicing-address-postcode'
+    ],
+    next: '/invoicing-contact-details'
+  },
 
-    '/who-completing-application': {
-      next: '/confirm'
-    },
+  '/invoicing-contact-details': {
+    behaviours: [customValidation],
+    fields: [
+      'invoicing-contact-name',
+      'invoicing-contact-email',
+      'invoicing-contact-telephone',
+      'invoicing-purchase-order-number',
+      'refund-accound-details'
+    ],
+    next: '/licence-email-address'
+  },
+
+  '/licence-email-address': {
+    fields: ['licence-email-address'],
+    next: '/who-completing-application'
+  },
+
+  '/who-completing-application': {
+    next: '/confirm'
+  },
 
   /** Continue an application */
 

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -405,7 +405,7 @@ module.exports = {
       {
         step: '/licence-email-address',
         field: 'licence-email-address'
-      },
+      }
     ]
   }
 };

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -365,7 +365,47 @@ module.exports = {
       {
         step: '/thc-content-level',
         field: 'thc-content-level'
-      }
+      },
+      {
+        step: '/invoicing-address',
+        field: 'invoicing-address',
+        parse: (list, req) => {
+          const invoicingAddress = [
+            req.sessionModel.get('invoicing-address-line-1'),
+            req.sessionModel.get('invoicing-address-line-2'),
+            req.sessionModel.get('invoicing-address-town-or-city'),
+            req.sessionModel.get('invoicing-address-postcode')
+          ];
+          return invoicingAddress.filter(element => element).join('\n');
+        }
+      },
+      {
+        step: '/invoicing-contact-details',
+        field: 'invoicing-contact-name'
+      },
+      {
+        step: '/invoicing-contact-details',
+        field: 'invoicing-contact-email'
+      },
+      {
+        step: '/invoicing-contact-details',
+        field: 'invoicing-contact-telephone'
+      },
+      {
+        step: '/invoicing-contact-details',
+        field: 'invoicing-purchase-order-number',
+        parse: (value, req) => {
+          return value ? value : req.translate('journey.not-provided');
+        }
+      },
+      {
+        step: '/invoicing-contact-details',
+        field: 'refund-accound-details'
+      },
+      {
+        step: '/licence-email-address',
+        field: 'licence-email-address'
+      },
     ]
   }
 };

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -419,5 +419,39 @@
   "thc-content-level": {
     "label": "Provide the THC content level",
     "hint": "This must be lower than 0.2%"
+  },
+  "invoicing-address-line-1": {
+    "label": "Address line 1"
+  },
+  "invoicing-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "invoicing-address-town-or-city": {
+    "label": "Town or city"
+  },
+  "invoicing-address-postcode": {
+    "label": "Postcode"
+  },
+  "invoicing-contact-name": {
+    "label": "Contact name",
+    "hint": "Enter your contact's full name"
+  },
+  "invoicing-contact-email": {
+    "label": "Email address",
+    "hint": "Enter a shared email address to avoid delays in receiving invoices"
+  },
+  "invoicing-contact-telephone": {
+    "label": "Contact number"
+  },
+  "invoicing-purchase-order-number": {
+    "label": "Purchase order number (optional)",
+    "hint": "Enter a reference if your organisation needs a purchase order number to be quoted when the invoice is raised"
+  },
+  "refund-accound-details": {
+    "label": "Refund account details",
+    "hint": "This is where we should send any refunds to your organisation, where needed"
+  },
+  "licence-email-address": {
+    "label": "Which email address should we send the licence to?"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/journey.json
+++ b/apps/industrial-hemp/translations/src/en/journey.json
@@ -3,5 +3,6 @@
   "serviceName": "Industrial hemp application",
   "error": "Error",
   "warning": "Warning",
-  "uploading": "Uploading your file..."
+  "uploading": "Uploading your file...",
+  "not-provided": "Not provided"
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -56,6 +56,12 @@
   "record-keeping-document-images": {
     "header": "Upload images of your record keeping documents"
   },
+  "invoicing-address": {
+    "header": "Invoicing address"
+  },
+  "invoicing-contact-details": {
+    "header": "Invoicing contact details"
+  },
   "confirm": {
     "header": "Check your answers",
     "sections": {
@@ -204,6 +210,24 @@
       },
       "thc-content-level":{
         "label": "THC content level"
+      },
+      "invoicing-address": {
+        "label": "Invoicing address"
+      },
+      "invoicing-contact-name": {
+        "label": "Invoicing contact name"
+      },
+      "invoicing-contact-email": {
+        "label": "Invoicing contact email address"
+      },
+      "invoicing-contact-telephone": {
+        "label": "Invoicing contact number"
+      },
+      "invoicing-purchase-order-number": {
+        "label": "Purchase order number"
+      },
+      "licence-email-address": {
+        "label": "Email address for the licence"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -322,5 +322,50 @@
     "required": "Enter the THC content level",
     "maxlength": "THC content level must be 2,000 characters or less",
     "notUrl": "Your answer must not contain URLs or links"
+  },
+  "invoicing-address-line-1": {
+    "required": "Enter address line 1, typically the building and street",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 1 must be between 1 and 250 characters"
+  },
+  "invoicing-address-line-2": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Address line 2 must be between 1 and 250 characters"
+  },
+  "invoicing-address-town-or-city": {
+    "required": "Enter a town or city",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Town or city must be between 1 and 250 characters"
+  },
+  "invoicing-address-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a real UK postcode"
+  },
+  "invoicing-contact-name": {
+    "required": "Enter an invoicing contact name",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Invoicing contact name must be between 3 and 200 characters",
+    "minlength": "Invoicing contact name must be between 3 and 200 characters"
+  },
+  "invoicing-contact-email": {
+    "required": "Enter an invoicing contact email address",
+    "email": "Enter a real email address"
+  },
+  "invoicing-contact-telephone": {
+    "required": "Enter an invoicing contact number",
+    "internationalPhoneNumber": "Enter a real telephone number, like 07700 900000"
+  },
+  "invoicing-purchase-order-number": {
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Purchase order number must be between 1 and 250 characters"
+  },
+  "refund-accound-details": {
+    "required": "Enter your refund account details",
+    "maxlength": "Refund account details must be 500 characters or less",
+    "notUrl": "Your answer must not contain URLs or links"
+  },
+  "licence-email-address": {
+    "required": "Enter an email address where we should send the licence",
+    "email": "Enter a real email address"
   }
 }


### PR DESCRIPTION
## What? 

[CSL-188](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-188) -   Added /invoicing-address, /invoicing-contact-details, /licence-email-address pages in THC form flow 

## How? 
- Added necessary step configuration and field specific variables. 
- Added required field validation for all pages

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


