### PR TITLE
CSL-127 Add service name to headers on session timeout page

### DIFF
--- a/apps/views/session-timeout.html
+++ b/apps/views/session-timeout.html
@@ -1,4 +1,16 @@
 {{<error}}
+  {{$journeyHeader}}
+    {{#t}}journey.serviceName{{/t}}
+  {{/journeyHeader}}
+
+  {{$validationSummary}}
+    {{> partials-validation-summary}}
+  {{/validationSummary}}
+
+  {{$propositionHeader}}
+    {{> partials-navigation}}
+  {{/propositionHeader}}
+
   {{$pageTitle}}
     {{#t}}errors.session.title{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
   {{/pageTitle}}

--- a/apps/views/session-timeout.html
+++ b/apps/views/session-timeout.html
@@ -1,14 +1,8 @@
 {{<error}}
-  {{$journeyHeader}}
-    {{#t}}journey.serviceName{{/t}}
-  {{/journeyHeader}}
-
-  {{$validationSummary}}
-    {{> partials-validation-summary}}
-  {{/validationSummary}}
-
   {{$propositionHeader}}
-    {{> partials-navigation}}
+    <div class="govuk-header__content">
+        <a href="{{startLink}}" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">{{#t}}journey.serviceName{{/t}}</a>
+    </div>
   {{/propositionHeader}}
 
   {{$pageTitle}}


### PR DESCRIPTION
## What? 

[CSL-127](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-127)

Adds the service name / title to the black header bar in session-timeout.html

## Why? 

This information was not previously displayed in the template. As an error based template it does not inherit those values from page.html as normal pages do. This PR adds the dynamic header values for session-timeout.html which enables the heading.

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


