### PR TITLE
CSL 180 different postcode

### DIFF
--- a/apps/industrial-hemp/fields/index.js
+++ b/apps/industrial-hemp/fields/index.js
@@ -822,5 +822,34 @@ module.exports = {
     validate: [ { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
     attributes: [{ attribute: 'rows', value: 8 }],
     isPageHeading: true
+  },
+  'is-different-postcodes': {
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: [ 'required' ],
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'different-postcode-details': {
+    mixin: 'textarea',
+    validate: ['required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }],
+    isPageHeading: true
+  },
+  'adjacent-field-details': {
+    mixin: 'textarea',
+    validate: ['required', { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
+    attributes: [{ attribute: 'rows', value: 8 }],
+    isPageHeading: true
   }
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -455,15 +455,27 @@ const steps = {
   '/other-operating-businesses': {
     next: '/different-postcodes'
   },
-
   '/different-postcodes': {
+    fields: ['is-different-postcodes'],
+    forks: [
+      {
+        target: '/different-postcode-addresses',
+        condition: {
+          field: 'is-different-postcodes',
+          value: 'yes'
+        }
+      }
+    ],
     next: '/adjacent-to-fields'
   },
-
+  '/different-postcode-addresses': {
+    fields: ['different-postcode-details'],
+    next: '/adjacent-to-fields'
+  },
   '/adjacent-to-fields': {
+    fields: ['adjacent-field-details'],
     next: '/perimeter-details'
   },
-
   '/perimeter-details': {
     next: '/perimeter-images'
   },

--- a/apps/industrial-hemp/sections/summary-data-sections.js
+++ b/apps/industrial-hemp/sections/summary-data-sections.js
@@ -432,6 +432,18 @@ module.exports = {
         parse: (value, req) => {
           return value ? value : req.translate('journey.not-provided');
         }
+      },
+      {
+        step: '/different-postcodes',
+        field: 'is-different-postcodes'
+      },
+      {
+        step: '/different-postcode-addresses',
+        field: 'different-postcode-details'
+      },
+      {
+        step: '/adjacent-to-fields',
+        field: 'adjacent-field-details'
       }
     ]
   }

--- a/apps/industrial-hemp/translations/src/en/fields.json
+++ b/apps/industrial-hemp/translations/src/en/fields.json
@@ -480,5 +480,23 @@
   },
   "extra-information": {
     "label": "Add any extra information you think might help your application (optional)"
+  },
+  "is-different-postcodes": {
+    "legend": "Are any of the fields in a different postcode to the site address?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "different-postcode-details": {
+    "label": "Provide the addresses of the fields that are in a different postcode"
+  },
+  "adjacent-field-details": {
+    "label": "What is adjacent to each of the fields you intend to cultivate?",
+    "hint": "If you have multiple fields, refer to each one by its Ordnance Survey grid reference"
   }
 }

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -252,6 +252,15 @@
       },
       "extra-information": {
         "label": "Extra information"
+      },
+      "is-different-postcodes": {
+        "label": "Are any of the fields in a different postcode?"
+      },
+      "different-postcode-details": {
+        "label": "Addresses in another postcode"
+      },
+      "adjacent-field-details":{
+        "label": "What is adjacent to the fields you intend to cultivate?"
       }
     }
   }

--- a/apps/industrial-hemp/translations/src/en/validation.json
+++ b/apps/industrial-hemp/translations/src/en/validation.json
@@ -393,5 +393,18 @@
   "extra-information": {
     "notUrl": "Your answer must not contain URLs or links",
     "maxlength": "Extra information about your application must be 2,000 characters or less"
+  },
+  "is-different-postcodes": {
+    "required": "Select if any of the fields are in a different postcode to the site address"
+  },
+  "different-postcode-details":{
+    "required": "Enter the addresses of the fields that are in a different postcode",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Addresses of the fields that are in a different postcode must be 2,000 characters or less"
+  },
+  "adjacent-field-details": {
+    "required": "Enter what is adjacent to each of the fields you intend to cultivate",
+    "notUrl": "Your answer must not contain URLs or links",
+    "maxlength": "Details of what is adjacent to each of the fields you intend to cultivate must be 2,000 characters or less"
   }
 }


### PR DESCRIPTION
## What? 
[CSL-180](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-180) - Are any fields in a different postcode to the site address

## Why? 
[Are any fields in a different postcode to the site address
](https://www.figma.com/design/WNady81HOqgtqgI3L5kAia/CSL---Low-THC-Cannabis?node-id=1-13216&t=YCetZ0bdD17R9I6T-4)

[Provide the addresses of the fields that are in different postcodes](https://www.figma.com/design/WNady81HOqgtqgI3L5kAia/CSL---Low-THC-Cannabis?node-id=1-15436&t=YCetZ0bdD17R9I6T-4)

[What is adjacent to the fields you intend to cultivate?](https://www.figma.com/design/WNady81HOqgtqgI3L5kAia/CSL---Low-THC-Cannabis?node-id=1-15652&t=YCetZ0bdD17R9I6T-4)

## How? 
- Added necessary page to render fields
- Added validation control and error message
- Added fields

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


