### PR TITLE
CSL-191 -[REG]- add declaration and confirmation page

### DIFF
--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -269,7 +269,7 @@ module.exports = {
       'required',
       'date',
       { type: 'before', arguments: ['0', 'days'] },
-      { type: 'after', arguments: ['100', 'years'] } // Validate the date to be less than 100 years in the past
+      { type: 'after', arguments: ['2002-12-31'] }
     ],
     legend: {
       className: 'govuk-!-margin-bottom-4'

--- a/apps/registration/fields/index.js
+++ b/apps/registration/fields/index.js
@@ -280,5 +280,9 @@ module.exports = {
     validate: [ { type: 'maxlength', arguments: 2000 }, 'notUrl' ],
     attributes: [{ attribute: 'rows', value: 8 }],
     isPageHeading: true
+  },
+  'declaration-check': {
+    mixin: 'checkbox',
+    validate: ['required']
   }
 };

--- a/apps/registration/index.js
+++ b/apps/registration/index.js
@@ -215,6 +215,7 @@ const steps = {
   },
 
   '/declaration': {
+    fields: ['declaration-check'],
     next: '/registration-submitted'
   },
 

--- a/apps/registration/translations/src/en/fields.json
+++ b/apps/registration/translations/src/en/fields.json
@@ -144,7 +144,8 @@
     "label": "Registration number"
   },
   "date-of-registration": {
-    "legend": "Date of registration"
+    "legend": "Date registered",
+    "hint": "For example, 27 3 2019"
   },
   "regulatory-body-registration-details": {
     "label": "Provide details of any other regulatory bodies you are registered with (optional)",

--- a/apps/registration/translations/src/en/fields.json
+++ b/apps/registration/translations/src/en/fields.json
@@ -149,5 +149,8 @@
   "regulatory-body-registration-details": {
     "label": "Provide details of any other regulatory bodies that you are registered with (optional)",
     "hint": "For example the Veterinary Medicines Directorate, the United Kingdom Accreditation Service or the Food Standards Agency"
+  },
+  "declaration-check": {
+    "label": "I have read and agree to this declaration"
   }
 }

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -39,6 +39,15 @@
     "pageTitle": "Care Quality Commission registration details"
   },
 
+  "declaration": {
+    "header": "Declaration"
+  },
+
+  "registration-submitted": {
+    "confirmed": "Registration submitted",
+    "emailIntro": "Confirmation email sent to"
+  },
+
   "confirm": {
     "header": "Check your answers before submitting your registration",
     "sections": {

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -44,8 +44,7 @@
   },
 
   "registration-submitted": {
-    "confirmed": "Registration submitted",
-    "emailIntro": "Confirmation email sent to"
+    "confirmed": "Registration submitted"
   },
 
   "confirm": {

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -8,6 +8,10 @@
     "header": "Licence holder details"
   },
 
+  "previously-held-licence": {
+    "pageTitle": "Did you previously hold a controlled drugs licence? "
+  },
+
   "licence-holder-address": {
     "header": "Licence holder address",
     "intro": "This is the address your business is registered at."
@@ -20,6 +24,11 @@
     "key": "Business type",
     "otherKey": "Other business type"
   },
+
+  "company-type": {
+    "pageTitle": "Are you a private or public limited company?"
+  },
+
   "upload-company-certificate": {
     "header": "Upload company registration certificate",
     "intro": "Upload a scanned copy of your company registration certificate."

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -132,7 +132,7 @@
     "required": "Enter the date  your organisation registered with the CQC or its equivalents",
     "date": "Enter a real date when you registered with the CQC or its equivalents",
     "before": "Date you registered with the CQC or its equivalents must be in the past",
-    "after": "Registration with the CQC or its equivalent must have happened within the last 100 years"
+    "after": "Date of registration must be on or after 1 January 2003"
   },
   "regulatory-body-registration-details": {
     "maxlength": "Details of other regulatory bodies you are registered with must be 2,000 characters or less",

--- a/apps/registration/translations/src/en/validation.json
+++ b/apps/registration/translations/src/en/validation.json
@@ -137,5 +137,8 @@
   "regulatory-body-registration-details": {
     "maxlength": "Details of other regulatory bodies you are registered with must be 2,000 characters or less",
     "notUrl": "Your answer must not contain URLs or links"
+  },
+  "declaration-check": {
+    "required": "Confirm you have read and agree to this declaration"
   }
 }

--- a/apps/registration/views/content/en/declaration.md
+++ b/apps/registration/views/content/en/declaration.md
@@ -1,0 +1,4 @@
+I agree:
+
+- that the person responsible for regulatory affairs and compliance will discharge all licence responsibilities
+- that statistical returns will be submitted on an annual basis (if applicable)

--- a/apps/registration/views/content/en/reg-application-submitted.md
+++ b/apps/registration/views/content/en/reg-application-submitted.md
@@ -1,3 +1,5 @@
+Confirmation email sent to <a href="mailto:{{values.email}}" class="govuk-link">{{values.email}}</a>.
+
 Your confirmation email contains your username. You will receive a separate email with your password.
 
 ## What happens next

--- a/apps/registration/views/content/en/reg-application-submitted.md
+++ b/apps/registration/views/content/en/reg-application-submitted.md
@@ -1,0 +1,14 @@
+Your confirmation email contains your username. You will receive a separate email with your password.
+
+## What happens next
+
+If we approve your registration request, we will send you email confirmation in 3 to 5 working days.
+
+If you do not receive an email after 5 working days, contact us:
+
+
+<div class="govuk-inset-text">
+By phone on 0300 105 0248
+
+By email at <a href="mailto:DFLU.dom@homeoffice.gov.uk" class="govuk-link">DFLU.dom@homeoffice.gov.uk</a>.
+</div>

--- a/apps/registration/views/declaration.html
+++ b/apps/registration/views/declaration.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}declaration{{/markdown}}
+    {{#renderField}}declaration-check{{/renderField}}
+    <div id="loader-container"></div>
+    <div id="report-submit">{{#input-submit}}submit-registration{{/input-submit}}</div>
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/registration/views/registration-submitted.html
+++ b/apps/registration/views/registration-submitted.html
@@ -12,7 +12,6 @@
 
   <!-- @todo: Display application reference number here from iCasework -->
 
-  {{#t}}pages.registration-submitted.emailIntro{{/t}} <a href="mailto:{{values.email}}" class="govuk-link">{{values.email}}</a>.
   {{#markdown}}reg-application-submitted{{/markdown}}
 
   {{/page-content}}

--- a/apps/registration/views/registration-submitted.html
+++ b/apps/registration/views/registration-submitted.html
@@ -1,0 +1,19 @@
+{{<partials-page}}
+  {{$pageTitle}}
+    {{#t}}pages.registration-submitted.confirmed{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$page-content}}
+  
+  <div class="govuk-panel alert-complete govuk-panel--confirmation">
+    <h1 class="govuk-panel__title">
+      {{#t}}pages.registration-submitted.confirmed{{/t}}
+    </h1>
+  </div>
+
+  <!-- @todo: Display application reference number here from iCasework -->
+
+  {{#t}}pages.registration-submitted.emailIntro{{/t}} <a href="mailto:{{values.email}}" class="govuk-link">{{values.email}}</a>.
+  {{#markdown}}reg-application-submitted{{/markdown}}
+
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/views/company-type.html
+++ b/apps/views/company-type.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+  {{$pageTitle}}
+  {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}} {{#t}}pages.company-type.pageTitle{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$page-content}}
+    {{#renderField}}company-type{{/renderField}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/views/previously-held-licence.html
+++ b/apps/views/previously-held-licence.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+  {{$pageTitle}}
+  {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}} {{#t}}pages.previously-held-licence.pageTitle{{/t}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$page-content}}
+    {{#renderField}}previously-held-licence{{/renderField}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 

Relates [CSL-191](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-191)
Includes update changes from [CSL-174](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-174) && figma updates
* adds declaration and confirmation pages

application reference number is todo until iCasework is integrated 

## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


