### PR TITLE
CSL - 246 - Generate unique username in utils

### DIFF
--- a/test/unit/user-registration.test.js
+++ b/test/unit/user-registration.test.js
@@ -1,0 +1,36 @@
+const { generateUniqueUsername } = require('../../utils/user-registration');
+
+jest.mock('hof/lib/logger', () => {
+  return jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }));
+});
+
+describe('generateUniqueUsername', () => {
+  it('should generate base username when no lastGeneratedUsername is provided', () => {
+    const result = generateUniqueUsername('TechCorp', 'CR1 9RA', null);
+    expect(result).toBe('techccr1');
+  });
+
+  it('should handle empty lastGeneratedUsername gracefully', () => {
+    const result = generateUniqueUsername('TechCorp', 'CR1 9RA', '');
+    expect(result).toBe('techccr1');
+  });
+
+  it('should append 1 if lastGeneratedUsername is same as baseUsername', () => {
+    const result = generateUniqueUsername('TechCorp', 'CR1 9RA', 'techccr1');
+    expect(result).toBe('techccr11');
+  });
+
+  it('should increment suffix if lastGeneratedUsername has a numeric suffix', () => {
+    const result = generateUniqueUsername('TechCorp', 'CR1 9RA', 'techccr12');
+    expect(result).toBe('techccr13');
+  });
+
+  it('should use full company name if it is shorter than 5 characters', () => {
+    const result = generateUniqueUsername('ABC', 'E1 6AN', null);
+    expect(result).toBe('abce1');
+  });
+});

--- a/utils/user-registration.js
+++ b/utils/user-registration.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Generates a unique username based on the company name, postcode, and the last generated username.
+ * @param {string} companyName - The name of the company to include the part in username
+ * @param {string} postcode - The postcode to include in the username
+ * @param {string} lastGeneratedUsername - The last username that was generated, used to increment the suffix.
+ * @returns {string} - A unique, lowercase username string.
+ */
+function generateUniqueUsername(companyName, postcode, lastGeneratedUsername) {
+  const companyNamePart = companyName.length < 5 ? companyName : companyName.slice(0, 5);
+  const postcodePart = postcode.slice(0, 3).trimEnd();
+  let username = (companyNamePart + postcodePart).toLowerCase();
+
+  // Append an incremented integer suffix to the username if lastGeneratedUsername is provided
+  if (lastGeneratedUsername) {
+    const suffix = lastGeneratedUsername.replace(username, '');
+    const counter = suffix === '' ? 1 : Number(suffix) + 1;
+    username = username + counter;
+  }
+
+  return username;
+}
+
+module.exports = {
+  generateUniqueUsername
+};


### PR DESCRIPTION
## What? 
[CSL-246](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-246) - Username generation

## Why? 
Registration form submission involves implementing create user. The process includes generating a unique username and password, creating the user in Keycloak, and storing the user record in the CSL database.

## How? 
In this particular ticket, have created a generateUniqueUsername util function to get the username during create user step.
The username is composed of:
- The first 5 characters of the company name (or the full name if it's shorter than 5 characters).
- The first 3 characters of the postcode (with trailing whitespace removed).
- The resulting string is converted to lowercase.

If a lastGeneratedUsername is provided (indicating a username already exists), the function:
- Extracts the numeric suffix from the last generated username.
- Increments the suffix by 1.
- Appends the new suffix to the base username to ensure uniqueness.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


