### PR TITLE
CSL - 272 - Updated rds api new image and parsed username input to uppercase

### DIFF
--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -59,7 +59,7 @@ services:
       - "8082:8082"
 
   rds-api:
-    image: quay.io/ukhomeofficedigital/hof-rds-api:a27f07f7865a0a5c38032fb55c114b1673c41796
+    image: quay.io/ukhomeofficedigital/hof-rds-api:3.1.1@sha256:68ae6f0a0dfd9ce85d3bc3575d61c353777fe2c33f07915ee9eb149b99478159
     networks:
       - csl-shared-network
     hostname: hof-rds-api

--- a/apps/common/behaviours/auth/sign-in.js
+++ b/apps/common/behaviours/auth/sign-in.js
@@ -12,7 +12,7 @@ module.exports = superclass => class extends superclass {
       new this.ValidationError(key, { type: type});
 
     try {
-      const applicantId = await getApplicantId(req.form.values.username);
+      const applicantId = await getApplicantId(req.form.values.username?.toUpperCase());
       if (!applicantId) {
         const errorMessage = 'Failed to retrieve applicant ID';
         throw new Error(errorMessage);

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -38,7 +38,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:a27f07f7865a0a5c38032fb55c114b1673c41796
+          image: quay.io/ukhomeofficedigital/hof-rds-api:3.1.1@sha256:68ae6f0a0dfd9ce85d3bc3575d61c353777fe2c33f07915ee9eb149b99478159
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What? 
[CSL-272](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-272) -  Add mock users to seed script

## Why? 
The current seed script for the applicants table only inserts a single user. Adding mock users to seed script

## How? 
Updated the code to use the new hof-rds-api image and parsed the username input value as uppercase before auth process

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


