### PR TITLE
Update hof-rds-api and html-pdf-converter configuration

### DIFF
--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -37,8 +37,7 @@ spec:
     spec:
       containers:
         - name: data-service
-          # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:3.1.1@sha256:68ae6f0a0dfd9ce85d3bc3575d61c353777fe2c33f07915ee9eb149b99478159
+          image: quay.io/ukhomeofficedigital/hof-rds-api:3.1.2@sha256:1b48e63b3a28a2d748f7b02de5b66a1a37f5d9920e8e226b93b5f45d44f8388c
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -15,9 +15,11 @@ metadata:
   {{ end }}
 spec:
   {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-  replicas: 2
-  {{ else }}
+  replicas: 5
+  {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
   replicas: 1
+  {{ else }}
+  replicas: 2
   {{ end }}
   selector:
     matchLabels:
@@ -49,8 +51,9 @@ spec:
           resources:
             requests:
               memory: 1024Mi
+              cpu: 300m
             limits:
-              cpu: 200m
+              cpu: 500m
               memory: 2048Mi
           env:
             - name: APP_PORT


### PR DESCRIPTION
## What? 

Update hof-rds-api to `3.1.2`
Increase resources available to html-pdf-converter pods

## Why? 

hof-rds-api v3.1.2 includes a new migration changing the applicant_id sequence default. This protects id values up to 20000 which is the potential range that legacy migrated users ids might occupy.

pdf-converter performance slows submission waiting time. Increasing resource requirements will spread the request load further and offer more CPU to processing. These values and management of them can be reassessed later.

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


