### PR TITLE
CSL-286, 293, 294, 295 - Content change - Licence holder details/Licence holder address

### DIFF
--- a/apps/controlled-drugs/translations/src/en/pages.json
+++ b/apps/controlled-drugs/translations/src/en/pages.json
@@ -165,10 +165,10 @@
         "label": "Requesting a change of activity"
       },
       "licence-holder-details": {
-        "label": "Licence holder details"
+        "label": "Company details"
       },
       "licence-holder-address": {
-        "label": "Licence holder address"
+        "label": "Company registered address"
       },
       "is-premises-address-same": {
         "label": "Re-use the same contact details for the premises"

--- a/apps/industrial-hemp/translations/src/en/pages.json
+++ b/apps/industrial-hemp/translations/src/en/pages.json
@@ -113,10 +113,10 @@
         "label": "Licensee type"
       },
       "licence-holder-details": {
-        "label": "Licence holder details"
+        "label": "Company details"
       },
       "licence-holder-address": {
-        "label": "Licence holder address"
+        "label": "Company registered address"
       },
       "growing-location-address": {
         "label": "Growing location address"

--- a/apps/precursor-chemicals/translations/src/en/pages.json
+++ b/apps/precursor-chemicals/translations/src/en/pages.json
@@ -168,10 +168,10 @@
         "label": "Change of name"
       },
       "licence-holder-details": {
-         "label": "Licence holder details"
+         "label": "Company details"
       },
        "licence-holder-address": {
-         "label": "Licence holder address"
+         "label": "Company registered address"
       },
       "is-premises-address-same": {
         "label": "Re-use the same contact details for the premises"

--- a/apps/registration/translations/src/en/pages.json
+++ b/apps/registration/translations/src/en/pages.json
@@ -76,10 +76,10 @@
     "header": "Check your answers before submitting your registration",
     "sections": {
       "licence-holder-details": {
-        "header": "Licence holder details"
+        "header": "Company details"
       },
       "licence-holder-address": {
-        "header": "Licence holder address"
+        "header": "Company registered address"
       },
       "business-details": {
         "header": "Business details"
@@ -92,9 +92,6 @@
       }
     },
     "fields": {
-      "company-name": {
-        "label": "Licence holder name"
-      },
       "telephone": {
         "label": "Contact phone number"
       },


### PR DESCRIPTION
## What? 
[CSL-286](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-286) - Reg 
[CSL-293](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-293) - PC
[CSL-294](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-294) - CD
[CSL-295](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-295) - Low THC

## Why? 
Content change in all forms 
`Licence holder details` should be changed to `Company details`
`Licence holder address` should be changed to `Company registered address`

In registration,` Licence holder name` is changed to `Company name` in summary.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


