### PR TITLE
CSL-300: Conditional PDF H1 for amendment type applications

### DIFF
--- a/.devcontainer/devtools/icasework-mock/icasework-mock.js
+++ b/.devcontainer/devtools/icasework-mock/icasework-mock.js
@@ -7,7 +7,7 @@ app.post('/token', (req, res) => {
 });
 
 app.post('/createcase', (req, res) => {
-  res.json({ createcaseresponse: { caseid: 'MOCK-CASE-12345' } });
+  res.json({ createcaseresponse: { caseid: '10000001' } });
 });
 
 app.listen(4000, () => {

--- a/test/unit/pdf-converter.test.js
+++ b/test/unit/pdf-converter.test.js
@@ -31,7 +31,8 @@ describe('PDFConverter class: ', () => {
     pdfConfig = {
       htmlLang: 'en',
       licenceType: 'precursor-chemicals',
-      licenceLabel: 'Precursor chemicals'
+      licenceLabel: 'Precursor chemicals',
+      amendment: false
     };
 
     locals = {
@@ -203,6 +204,26 @@ describe('PDFConverter class: ', () => {
         dateTime: '13 May 2025 at 11:54:11'
       }), expect.any(Function));
     });
+
+    it('uses amendment title variation if amendment is true in pdfConfig', async () => {
+      pdfConfig.amendment = true;
+      await pdfConverter.renderHTML(res, locals, pdfConfig, files);
+      expect(res.render).toHaveBeenCalledWith('pdf.html', Object.assign({}, sortedLocals, {
+        htmlLang: 'en',
+        css: 'I am a CSS',
+        'ho-logo': 'I am an image',
+        title: 'Amending precursor chemicals licence application',
+        dateTime: '13 May 2025 at 11:54:11',
+        addFilesSection: true,
+        files: [
+          {
+            field: 'certificate-of-good-conduct',
+            urls: ['url', 'url'],
+            label: 'Applicant certificate of good conduct'
+          }
+        ]
+      }), expect.any(Function));
+    });
   });
 
   describe('createBaseConfig method', () => {
@@ -226,12 +247,35 @@ describe('PDFConverter class: ', () => {
             'licence-type': 'precursor-chemicals'
           }
         },
+        sessionModel: {
+          get: jest.fn().mockReturnValue('new-application')
+        },
         translate: jest.fn().mockReturnValue('Precursor chemicals')
       };
       const setConfig = pdfConverter.createBaseConfig(req, res);
       expect(setConfig).toHaveProperty('htmlLang', 'fr');
       expect(setConfig).toHaveProperty('licenceType', 'precursor-chemicals');
       expect(setConfig).toHaveProperty('licenceLabel', 'Precursor chemicals');
+      expect(setConfig).toHaveProperty('amendment', false);
+    });
+
+    it('returns expected config for an amendment type application', () => {
+      req = {
+        session: {
+          'hof-wizard-common': {
+            'licence-type': 'precursor-chemicals'
+          }
+        },
+        sessionModel: {
+          get: jest.fn().mockReturnValue('amend-application')
+        },
+        translate: jest.fn().mockReturnValue('Precursor chemicals')
+      };
+      const setConfig = pdfConverter.createBaseConfig(req, res);
+      expect(setConfig).toHaveProperty('htmlLang', 'en');
+      expect(setConfig).toHaveProperty('licenceType', 'precursor-chemicals');
+      expect(setConfig).toHaveProperty('licenceLabel', 'Precursor chemicals');
+      expect(setConfig).toHaveProperty('amendment', true);
     });
   });
 

--- a/utils/pdf-converter.js
+++ b/utils/pdf-converter.js
@@ -47,12 +47,9 @@ module.exports = class PDFConverter extends HofPdfConverter {
     localContent.htmlLang = htmlLang;
     localContent.css = await this.readCss();
     localContent['ho-logo'] = await this.readHOLogo();
-
-    if (amendment) {
-      localContent.title = `Amending ${licenceLabel.toLowerCase()} licence application`;
-    } else {
-      localContent.title = `Apply for a domestic licence for controlled substances: ${licenceLabel}`;
-    }
+    localContent.title = amendment ?
+      `Amending ${licenceLabel.toLowerCase()} licence application` :
+      `Apply for a domestic licence for controlled substances: ${licenceLabel}`;
 
     const pdfDateFormat = Object.assign({}, dateFormat, timeFormat);
     localContent.dateTime = new Intl.DateTimeFormat(dateLocales, pdfDateFormat).format(Date.now());

--- a/utils/pdf-converter.js
+++ b/utils/pdf-converter.js
@@ -38,7 +38,7 @@ module.exports = class PDFConverter extends HofPdfConverter {
   }
 
   async renderHTML(res, content, pdfConfig, files) {
-    const { htmlLang, licenceType, licenceLabel } = pdfConfig;
+    const { htmlLang, licenceType, licenceLabel, amendment } = pdfConfig;
     const { dateFormat, timeFormat, dateLocales } = config;
 
     let localContent = Object.assign({}, content);
@@ -47,7 +47,12 @@ module.exports = class PDFConverter extends HofPdfConverter {
     localContent.htmlLang = htmlLang;
     localContent.css = await this.readCss();
     localContent['ho-logo'] = await this.readHOLogo();
-    localContent.title = `Apply for a domestic licence for controlled substances: ${licenceLabel}`;
+
+    if (amendment) {
+      localContent.title = `Amending ${licenceLabel.toLowerCase()} licence application`;
+    } else {
+      localContent.title = `Apply for a domestic licence for controlled substances: ${licenceLabel}`;
+    }
 
     const pdfDateFormat = Object.assign({}, dateFormat, timeFormat);
     localContent.dateTime = new Intl.DateTimeFormat(dateLocales, pdfDateFormat).format(Date.now());
@@ -72,7 +77,8 @@ module.exports = class PDFConverter extends HofPdfConverter {
     }
     const licenceType = req.session['hof-wizard-common']?.['licence-type'];
     const licenceLabel = translateOption(req, 'licence-type', licenceType);
-    return { htmlLang, licenceType, licenceLabel };
+    const amendment = req.sessionModel.get('application-form-type') === 'amend-application';
+    return { htmlLang, licenceType, licenceLabel, amendment };
   }
 
   async generatePdf(req, res, locals, pdfConfig, files) {


### PR DESCRIPTION
## What? 

Adds a conditional H1 to generated drugs application submission PDFs (applicant and business) where if the value for `application-type` was `amend-application` the title instead has the new format `Amending ${licenceLabel.toLowerCase()} licence application`.

This is to add to work in #188 where a new type is added for amendment type submissions.

## Why? 

Business request as the inclusion of 'Amendment' in the PDF title helps caseworkers to identify amendment type applications.

## Testing?

Unit tests updated to check this new behaviour. 
Tested locally

## Anything Else? (optional)

Updates the returned mock caseid from the local icasework-mock server. The reason for this is that the DB expects an `integer` in the `icasework_case_id` column when adding that column during completion of a submitted drugs application. 

This DB patch will fail unless the value returned is of type `integer` or at least parseable to an `integer`

## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)


