### PR TITLE
Fix missing applicant-id and value for registered-charity in registra…

### DIFF
--- a/apps/registration/behaviours/submit-request.js
+++ b/apps/registration/behaviours/submit-request.js
@@ -77,6 +77,7 @@ module.exports = superclass => class extends superclass {
       const registeredUser = await userCreator.registerUser(userDetails, authToken);
       const applicantId = await userCreator.addUserToApplicants(registeredUser);
       Object.assign(userDetails, registeredUser, { applicantId });
+      req.sessionModel.set('applicant-id', userDetails.applicantId);
       req.sessionModel.set('applicant-username', userDetails.username);
     } catch (error) {
       const errorMsg = `Failed to create new user: ${error}`;

--- a/utils/icasework/build-case-data.js
+++ b/utils/icasework/build-case-data.js
@@ -1,4 +1,4 @@
-const { getLabel, joinNonEmptyLines, formatDate, findArrayItemByValue, translateOption } = require('../../utils');
+const { joinNonEmptyLines, formatDate, findArrayItemByValue, translateOption } = require('../../utils');
 const businessTypeOptions = require('../../apps/registration/data/business-type.json');
 
 /**
@@ -86,9 +86,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         ...documents,
         Type: 'Hemp', // Identifier code on iCasework system - 48705
         'Applicant.Id': req.sessionModel.get('applicant-id'),
-        Renewal: getLabel(
+        Renewal: translateOption(
+          req,
           'licensee-type',
-          req.sessionModel.get('licensee-type')),
+          req.sessionModel.get('licensee-type')
+        ),
         LegalIdentity: '',
         PreviousLicence: '',
         PreviousName: '',
@@ -124,9 +126,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         WitnessEmail: req.sessionModel.get('authorised-witness-email'),
         WitnessDbsCheck: 'Yes',
         WitnessDisclosure: formatDate(req.sessionModel.get('authorised-witness-dbs-date-of-issue')),
-        HoLicencesAlreadyHeld: getLabel(
+        HoLicencesAlreadyHeld: translateOption(
+          req,
           'hold-other-regulatory-licences',
-          req.sessionModel.get('hold-other-regulatory-licences')),
+          req.sessionModel.get('hold-other-regulatory-licences')
+        ),
         NumberHempFields: req.sessionModel.get('how-many-fields'),
         HempFieldsDetails: req.sessionModel.get('cultivation-field-details'),
         OwnFields: req.sessionModel.get('who-own-fields'),
@@ -142,9 +146,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         ...documents,
         Type: 'ControlledDrugs', // Identifier code on iCasework system - 48272
         'Applicant.Id': req.sessionModel.get('applicant-id'),
-        Renewal: getLabel(
+        Renewal: translateOption(
+          req,
           'licensee-type',
-          req.sessionModel.get('licensee-type')),
+          req.sessionModel.get('licensee-type')
+        ),
         LegalIdentity: '',
         PreviousLicence: '',
         PreviousName: '',
@@ -203,9 +209,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         ...documents,
         Type: 'PrecursorChemicals', // Identifier code on iCasework system - 10000
         'Applicant.Id': req.sessionModel.get('applicant-id'),
-        Renewal: getLabel(
+        Renewal: translateOption(
+          req,
           'licensee-type',
-          req.sessionModel.get('licensee-type')),
+          req.sessionModel.get('licensee-type')
+        ),
         LegalIdentity: '',
         PreviousLicence: '',
         TimeRenewal: '',
@@ -241,9 +249,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         GuarEmailAddress: req.sessionModel.get('guarantor-email-address'),
         GuarDbsCheck: 'Yes',
         GuarDbsDisclosure: formatDate(req.sessionModel.get('guarantor-dbs-date-of-issue')),
-        CriminalConvictions: getLabel(
+        CriminalConvictions: translateOption(
+          req,
           'has-anyone-received-criminal-conviction',
-          req.sessionModel.get('has-anyone-received-criminal-conviction')),
+          req.sessionModel.get('has-anyone-received-criminal-conviction')
+        ),
         InvoicingPoNum: req.sessionModel.get('invoicing-purchase-order-number')
       };
     default:

--- a/utils/icasework/build-case-data.js
+++ b/utils/icasework/build-case-data.js
@@ -1,4 +1,4 @@
-const { getLabel, joinNonEmptyLines, formatDate, findArrayItemByValue } = require('../../utils');
+const { getLabel, joinNonEmptyLines, formatDate, findArrayItemByValue, translateOption } = require('../../utils');
 const businessTypeOptions = require('../../apps/registration/data/business-type.json');
 
 /**
@@ -265,9 +265,11 @@ function buildCaseData(req, applicationForm = null, applicationFiles = [], authT
         OrganisationBusinessNumber: req.sessionModel.get('company-number'),
         OrganisationPhone: req.sessionModel.get('telephone'),
         OrganisationEmail: req.sessionModel.get('email'),
-        OrganisationRegisteredCharity: getLabel(
+        OrganisationRegisteredCharity: translateOption(
+          req,
           'registered-charity',
-          req.sessionModel.get('registered-charity')),
+          req.sessionModel.get('registered-charity')
+        ),
         OrganisationBusinessType: parseAggregatedBusinessTypes(
           req.sessionModel.get('aggregated-business-type'))
       };


### PR DESCRIPTION
## What? 

- Fix icasework `buildCaseData.js` for registrations.
- Set `applicant-id` to session after it is created in the db
- Use `translateOption` rather than `getLabel` to get the label for the value of `registered-charity`

merge to CSL-300 PR #188 so it can be part of testing happening there

## Why? 

Applicant id is not being added to registration submissions properly so cases are not being linked in iCasework, although this appears to be working from the application submission side where the applicant id is visible, but does not create a visible link.

`translateOption` is a better translator of values than `getLabel` as `getLabel` uses precursor chemicals translations file and so will not translate any field where the app did not have the same field and values - e.g. `registered-charity`

## Anything Else? (optional)

the `getLabel` -> `translateOption` update should be made for all other field translation calls in this file that are not related to precursor-chemicals. There are a series of fields with values that are the same, but there may also be values that are not translating as a result of using `getLabel`

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


