### PR TITLE
CSL- 309 - Added attribute in user payload to update the attribute in keycloak

### DIFF
--- a/utils/user-creator.js
+++ b/utils/user-creator.js
@@ -81,7 +81,7 @@ module.exports = class UserCreator {
   * @throws {Error} Throws an error if required data are missing.
   */
   createRequestConfig(userDetails, authToken) {
-    const { username, password, email } = userDetails;
+    const { username, password, email, companyName } = userDetails;
 
     let errorMsg;
     if (!username || !password || !email) {
@@ -101,6 +101,10 @@ module.exports = class UserCreator {
       throw new Error(errorMsg);
     }
 
+    if (!companyName) {
+      logger.warn('Company name is missing or empty. Proceeding without setting the attribute.');
+    }
+
     const reqConfig = {
       url: `${config.keycloak.adminUrl}/users`,
       headers: {
@@ -112,6 +116,7 @@ module.exports = class UserCreator {
         enabled: true,
         email: email,
         emailVerified: false,
+        attributes: { 'Company name': companyName },
         credentials: [
           {
             type: 'password',


### PR DESCRIPTION
## What? 
[CSL-309](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-309) - Add company name attribute to user attributes section

## Why? 
The attribute section for each user has to be updated with company name in keycloak. so have added the attribute in user payload.
 
## How? 
companyName from registration is already added in userdetails object.
user payload in userCreator.createRequestConfig is updated with 
`attributes: { 'Company name': companyName }`

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


