### PR TITLE
CSL-394: Fixed the order of behaviour to save the form session first.

### DIFF
--- a/apps/controlled-drugs/index.js
+++ b/apps/controlled-drugs/index.js
@@ -969,5 +969,5 @@ module.exports = {
   params: '/:action?/:id?/:edit?',
   confirmStep: '/confirm',
   steps: steps,
-  behaviours: [Auth, SaveFormSession, CustomRedirect, SetFeedbackUrl]
+  behaviours: [Auth, CustomRedirect, SaveFormSession, SetFeedbackUrl]
 };

--- a/apps/industrial-hemp/index.js
+++ b/apps/industrial-hemp/index.js
@@ -735,5 +735,5 @@ module.exports = {
   params: '/:action?/:id?/:edit?',
   steps: steps,
   confirmStep: '/confirm',
-  behaviours: [ Auth, SaveFormSession, CustomRedirect, SetFeedbackUrl]
+  behaviours: [ Auth, CustomRedirect, SaveFormSession, SetFeedbackUrl]
 };

--- a/apps/precursor-chemicals/index.js
+++ b/apps/precursor-chemicals/index.js
@@ -551,5 +551,5 @@ module.exports = {
   params: '/:action?/:id?/:edit?',
   confirmStep: '/summary',
   steps: steps,
-  behaviours: [Auth, SaveFormSession, CustomRedirect, SetFeedbackUrl]
+  behaviours: [Auth, CustomRedirect, SaveFormSession, SetFeedbackUrl]
 };


### PR DESCRIPTION
## What? 
Fixed the order of the behaviour to perform save the form session before happening any custom redirect. 
The order is now saveFormSession, then customRedirect.
## Why? 
[https://collaboration.homeoffice.gov.uk/jira/browse/CSL-394](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-394)
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


