### PR TITLE
rearranging tear down

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -12,10 +12,19 @@ export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-exte
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-true}
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+
+  if [[ -z "${REDIS_PERSISTENCE_SIZE}" ]]; then
+    export REDIS_PERSISTENCE_SIZE=1Gi
+  fi
 
   $kd --delete -f kube/configmaps/configmap.yml -f kube/hof-rds-api
   $kd --delete -f kube/redis -f kube/html-pdf -f kube/app -f kube/file-vault
@@ -25,11 +34,6 @@ fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
-export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-true}
-export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
-export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
-export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
-export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
 
 if [[ -z "${REDIS_PERSISTENCE_SIZE}" ]]; then
   if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then


### PR DESCRIPTION
## What? 
Fixing error on tear down step

## Why? 
```

2026/03/19 11:04:34 skipping delete for resource (xxxxx) as it does not exist.
2026/03/19 11:04:34 skipping delete for resource (xxxxxx) as it does not exist.
2026/03/19 11:04:34 skipping delete for resource (xxxxxx) as it does not exist.
2026/03/19 11:04:34 skipping delete for resource (xxxxx) as it does not exist.
2026/03/19 11:04:34 skipping delete for resource (xxxxxx) as it does not exist.
[ERROR] 2026/03/19 11:04:34 main.go:248: template: template:22:18: executing "template" at <.REDIS_PERSISTENCE_S...>: map has no entry for key "REDIS_PERSISTENCE_SIZE"
```
## How? 
Changing the code to include deletion on the script upon merging

## Testing?
Merge in code

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


