### PR TITLE
CSL-395 - updating password generater to adhere to updated criteria i…

### DIFF
--- a/apps/registration/behaviours/submit-request.js
+++ b/apps/registration/behaviours/submit-request.js
@@ -1,7 +1,6 @@
 const config = require('../../../config');
 const { sendEmail, prepareUpload } = require('../../../utils/email-service');
 const { getApplicationFiles } = require('../../../utils');
-const { generatePassword } = require('../../../utils/pass-generator');
 
 const PDFConverter = require('../../../utils/pdf-converter');
 const FileUpload = require('../../../utils/file-upload');
@@ -62,11 +61,7 @@ module.exports = superclass => class extends superclass {
     const userDetails = {
       email: req.sessionModel.get('email'),
       companyName: req.sessionModel.get('company-name'),
-      companyPostcode: req.sessionModel.get('licence-holder-postcode'),
-      password: await generatePassword(
-        config.keycloak.passwordPolicy.length,
-        config.keycloak.passwordPolicy.characterSet
-      )
+      companyPostcode: req.sessionModel.get('licence-holder-postcode')
     };
 
     // Create user account in auth provider

--- a/config.js
+++ b/config.js
@@ -81,7 +81,7 @@ module.exports = {
     },
     passwordPolicy: {
       length: 16,
-      characterSet: 'ABCDEFGHJKMNPRTUVWXYabcdefghjkmnprtuvwxy0123456789!#$%&*+=?@'
+      characterSet: 'ABCDEFGHJKMNPRTUVWXYabcdefghjkmnprtuvwxy0123456789@!?='
     }
   },
   icasework: {

--- a/test/unit/pass-generator.test.js
+++ b/test/unit/pass-generator.test.js
@@ -18,6 +18,11 @@ describe('validatePassword', () => {
     expect(actual).toEqual(false);
   });
 
+  it('should return false if first character is not a letter or digit', () => {
+    const actual = validatePassword('?pc2yNhpDP+17Any');
+    expect(actual).toEqual(false);
+  });
+
   it('should return false if password not contain Uppercase', () => {
     const actual = validatePassword('7pc2ynhp?dp+1any');
     expect(actual).toEqual(false);
@@ -33,13 +38,23 @@ describe('validatePassword', () => {
     expect(actual).toEqual(false);
   });
 
-  it('should return false if password is more than 16 character', () => {
-    const actual = validatePassword('7pc2yNhp?DP+1Any16');
+  it('should return false if password contains more than one special character', () => {
+    const actual = validatePassword('7pc2yNhp?DP+1An');
+    expect(actual).toEqual(false);
+  });
+
+  it('should return false if password contains a special character outside @!?=', () => {
+    const actual = validatePassword('7pc2yNhp#DP61Any');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password less than 16 character', () => {
     const actual = validatePassword('7pc2yNhp?DP+1An');
+    expect(actual).toEqual(false);
+  });
+
+  it('should return false if password is same as username', () => {
+    const actual = validatePassword('7pc2yNhp?DP+1Any', '7pc2yNhp?DP+1Any');
     expect(actual).toEqual(false);
   });
 });
@@ -76,7 +91,7 @@ describe('generatePassword', () => {
   it('should generate password which most include special character', async () => {
     const actual =  [...await generatePassword(config.keycloak.passwordPolicy.length,
       config.keycloak.passwordPolicy)]
-      .some(char => /[!#$%&*+=?@]/.test(char));
+      .some(char => /[@!?=]/.test(char));
     expect(actual).toEqual(true);
   });
 

--- a/test/unit/pass-generator.test.js
+++ b/test/unit/pass-generator.test.js
@@ -3,58 +3,48 @@ const config = require('../../config');
 
 
 jest.unstable_mockModule('crypto-random-string', () => ({
-  default: jest.fn().mockReturnValue('7pc2yNhp?DP+1Any')
+  default: jest.fn().mockReturnValue('7pc2yNhp?DPb1Any')
 }));
 
 
 describe('validatePassword', () => {
   it('should return true if password is valid', () => {
-    const actual = validatePassword('7pc2yNhp?DP+1Any');
+    const actual = validatePassword('7pc2yNhp?DPb1Any', 'testuser1');
     expect(actual).toEqual(true);
   });
 
   it('should return false if password is not valid', () => {
-    const actual = validatePassword('#Rt8$I');
+    const actual = validatePassword('#Rt8$I', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if first character is not a letter or digit', () => {
-    const actual = validatePassword('?pc2yNhpDP+17Any');
+    const actual = validatePassword('?pc2yNhpDPb17Any', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password not contain Uppercase', () => {
-    const actual = validatePassword('7pc2ynhp?dp+1any');
+    const actual = validatePassword('7pc2ynhp?dpb1any', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password not contain Lowercase', () => {
-    const actual = validatePassword('7PC2YNHP?DP+1ANY');
+    const actual = validatePassword('7PC2YNHP?DPB1ANY', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password not contain ASCII value', () => {
-    const actual = validatePassword('7pc2yNhp4DP61Any');
-    expect(actual).toEqual(false);
-  });
-
-  it('should return false if password contains more than one special character', () => {
-    const actual = validatePassword('7pc2yNhp?DP+1An');
-    expect(actual).toEqual(false);
-  });
-
-  it('should return false if password contains a special character outside @!?=', () => {
-    const actual = validatePassword('7pc2yNhp#DP61Any');
+    const actual = validatePassword('7pc2yNhp4DP61Any', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password less than 16 character', () => {
-    const actual = validatePassword('7pc2yNhp?DP+1An');
+    const actual = validatePassword('7pc2yNhp?DPb1An', 'testuser1');
     expect(actual).toEqual(false);
   });
 
   it('should return false if password is same as username', () => {
-    const actual = validatePassword('7pc2yNhp?DP+1Any', '7pc2yNhp?DP+1Any');
+    const actual = validatePassword('7pc2yNhp?DPb1Any', '7pc2yNhp?DPb1Any');
     expect(actual).toEqual(false);
   });
 });
@@ -62,42 +52,42 @@ describe('validatePassword', () => {
 describe('generatePassword', () => {
   it('should generate password with length of 16', async () => {
     const actual = await generatePassword(config.keycloak.passwordPolicy.length,
-      config.keycloak.passwordPolicy.characterSet);
+      config.keycloak.passwordPolicy.characterSet, 'testuser1');
     expect(actual.length).toEqual(16);
   });
 
   it('should generate password and be a ASCII', async () => {
     const ascii = buffer => Buffer.from(buffer).toString('ascii');
     const actual = await generatePassword(config.keycloak.passwordPolicy.length,
-      config.keycloak.passwordPolicy.characterSet);
+      config.keycloak.passwordPolicy.characterSet, 'testuser1');
     expect(ascii(actual)).toEqual(actual);
   });
 
   it('it should generate password which include atleast uppercase',
     async () => {
       const actual = [... await generatePassword(config.keycloak.passwordPolicy.length,
-        config.keycloak.passwordPolicy.characterSet)]
+        config.keycloak.passwordPolicy.characterSet, 'testuser1')]
         .some(char => /[A-Z]/.test(char));
       expect(actual).toEqual(true);
     });
 
   it('should generate password which most include lowercase', async () => {
     const actual = [...await generatePassword(config.keycloak.passwordPolicy.length,
-      config.keycloak.passwordPolicy.characterSet)]
+      config.keycloak.passwordPolicy.characterSet, 'testuser1')]
       .some(char => /[a-z]/.test(char));
     expect(actual).toEqual(true);
   });
 
   it('should generate password which most include special character', async () => {
-    const actual =  [...await generatePassword(config.keycloak.passwordPolicy.length,
-      config.keycloak.passwordPolicy)]
+    const actual = [...await generatePassword(config.keycloak.passwordPolicy.length,
+      config.keycloak.passwordPolicy, 'testuser1')]
       .some(char => /[@!?=]/.test(char));
     expect(actual).toEqual(true);
   });
 
   it('it should generate password which most include Numeric', async () => {
     const actual = [...await generatePassword(config.keycloak.passwordPolicy.length,
-      config.keycloak.passwordPolicy.characterSet)]
+      config.keycloak.passwordPolicy.characterSet, 'testuser1')]
       .some(char => /\d/.test(char));
     expect(actual).toEqual(true);
   });

--- a/utils/pass-generator.js
+++ b/utils/pass-generator.js
@@ -3,6 +3,7 @@ const config = require('../config');
 const logger = require('hof/lib/logger')({ env: config.env });
 
 // At least one uppercase, one lowercase, length of 16 characters and first character must be letter or digit.
+// eslint-disable-next-line max-len
 const passwordPolicyRegex = /^(?=[A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@!?=])(?!.*[@!?=].*[@!?=])[A-Za-z@!?=0-9]{16}$/;
 
 /**

--- a/utils/pass-generator.js
+++ b/utils/pass-generator.js
@@ -2,16 +2,17 @@
 const config = require('../config');
 const logger = require('hof/lib/logger')({ env: config.env });
 
-// At least one uppercase, one lowercase, one special character, and one digit, and length of 16 characters
-const passwordPolicyRegex = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[!#$%&*+=?@])(?=.*\d)[A-Za-z!#$%&*+=?@0-9]{16}$/;
+// At least one uppercase, one lowercase, length of 16 characters and first character must be letter or digit.
+const passwordPolicyRegex = /^(?=[A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@!?=])(?!.*[@!?=].*[@!?=])[A-Za-z@!?=0-9]{16}$/;
 
 /**
  * Check if passward value is valid
  *
  * @param {string} value - random generated value from crypto-random-string
+ * @param {string} username - account username
  * @returns {bool}
  */
-const validatePassword = value => passwordPolicyRegex.test(value);
+const validatePassword = (value, username) => passwordPolicyRegex.test(value) && (value !== username);
 
 /**
   * Generates a password that meets the following requirements:
@@ -19,20 +20,20 @@ const validatePassword = value => passwordPolicyRegex.test(value);
   * - Must contain at least one uppercase letter.
   * - Must contain at least one lowercase letter.
   * - Must contain at least one digit.
-  * - Must contain at least one special character.
+  * - Must contain one special character.
  * @param {string} passwordLength - expected password length.
- * @param {string} characterSet - expected character set example('ABabc1234').
+ * @param {string} characterSet - expected character set example('ABabc1234@!?=').
  * @async
  * @returns {Promise<string>} A randomly generated password that satisfies the policy.
 */
-const generatePassword =  async (passwordLength, characterSet) => {
+const generatePassword =  async (passwordLength, characterSet, username) => {
   let randomPassword = '';
   let isPolicyMatch;
   try {
     const cryptoRandomString = await import('crypto-random-string');
     do{
       randomPassword = cryptoRandomString.default({length: passwordLength, characters: characterSet});
-      isPolicyMatch = validatePassword(randomPassword);
+      isPolicyMatch = validatePassword(randomPassword, username);
     }
     while(!isPolicyMatch);
   }catch(error) {

--- a/utils/user-creator.js
+++ b/utils/user-creator.js
@@ -7,6 +7,7 @@ const config = require('../config');
 const logger = require('hof/lib/logger')({ env: config.env });
 
 const { generateUniqueUsername } = require('./user-registration');
+const { generatePassword } = require('./pass-generator');
 
 module.exports = class UserCreator {
   constructor() {
@@ -139,15 +140,21 @@ module.exports = class UserCreator {
   * Generates a request configuration from user data and auth token.
   * If a request failed because the username was unavailable, generates a new username and recurses until successful
   *
+  * @async
   * @param {object} userDetails - The user data for the POST request.
   * @param {object} authToken - Contains a bearer token to authenticate the request.
   * @returns {<Promise>object} Returns collected data about the user that was successfully created.
   * @throws {Error} Throws an error if the request to create a user was unsuccessful.
   */
-  registerUser(userDetails, authToken) {
+  async registerUser(userDetails, authToken) {
     const { companyName, companyPostcode } = userDetails;
     this.username = generateUniqueUsername(companyName, companyPostcode, this.username);
     const prospectiveUser = Object.assign({}, userDetails, { username: this.username });
+    prospectiveUser.password = await generatePassword(
+      config.keycloak.passwordPolicy.length,
+      config.keycloak.passwordPolicy.characterSet,
+      prospectiveUser.username
+    );
     const userRequestConfig = this.createRequestConfig(prospectiveUser, authToken);
 
     logger.info(`Register user attempt: ${this.requestAttempts}`);


### PR DESCRIPTION
Relates to: 
- [CSL-395](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-395)
- Password generator mostly matched criteria already
- Added to adhere to updated criteria: first character to be letter or digit, password not be the same as username, and one special character to be: @ ! ? =
- Updated and added unit tests

## What? 
## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


