### PR TITLE
CSL-421: switch html-pdf-converter image to Alpine base

### DIFF
--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -45,7 +45,7 @@ spec:
         {{ else }}
         - name: html-pdf-converter
         {{ end }}
-          # html-pdf-converter: v3.0.0 updated on 23/01/2024
+          # html-pdf-converter: v3.1.0 updated on 27/07/2026
           image: quay.io/ukhomeofficedigital/html-pdf-converter:3.1.0@sha256:42b150c3c441f72ea5d4dc50673fb82e47b1705652bcf62c9b48836e3f70f8ed
           imagePullPolicy: Always
           resources:

--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -46,7 +46,7 @@ spec:
         - name: html-pdf-converter
         {{ end }}
           # html-pdf-converter: v3.0.0 updated on 23/01/2024
-          image: quay.io/ukhomeofficedigital/html-pdf-converter:3.0.0@sha256:2f13eb3bc9d396f2685e22a66b40613a44dfd9956412fe2752477601bb33772c
+          image: quay.io/ukhomeofficedigital/html-pdf-converter:3.1.0@sha256:42b150c3c441f72ea5d4dc50673fb82e47b1705652bcf62c9b48836e3f70f8ed
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**What?**
- Replaced html-pdf-converter image in kube manifests with Alpine-based image:
  quay.io/ukhomeofficedigital/html-pdf-converter:3.1.0@sha256:42b150c3c441f72ea5d4dc50673fb82e47b1705652bcf62c9b48836e3f70f8ed

**Why?**
- Ubuntu-based image has unresolved High/Critical CVEs due to missing upstream patches.
- Alpine aligns with HOF service baseline and security requirements.

**How?**
- Updated image references under kube/ only.
- No functional changes expected; OS-level security hardening only.